### PR TITLE
Fix Color Format detection and ProRes

### DIFF
--- a/data/locale/en-US.ini
+++ b/data/locale/en-US.ini
@@ -373,12 +373,12 @@ Codec.HEVC.Level.Description="Level determines the upper limits of resolution an
 
 # Codec: Apple ProRes
 Codec.ProRes.Profile="Profile"
-Codec.ProRes.Profile.APCO="422 Proxy/PXY (APCO)"
-Codec.ProRes.Profile.APCS="422 Light/LT (APCS)"
+Codec.ProRes.Profile.APCO="422 Proxy (APCO)"
+Codec.ProRes.Profile.APCS="422 Lite (APCS)"
 Codec.ProRes.Profile.APCN="422 Standard (APCN)"
 Codec.ProRes.Profile.APCH="422 High Quality/HQ (APCH)"
-Codec.ProRes.Profile.AP4H="4444 Standard (AP4H)"
-Codec.ProRes.Profile.AP4X="4444 Extra Quality/XQ (AP4X)"
+Codec.ProRes.Profile.AP4H="4444 High Quality (AP4H)"
+Codec.ProRes.Profile.AP4X="4444 Extrme Quality/XQ (AP4X)"
 
 # Encoder: FFmpeg
 FFmpegEncoder="FFmpeg Options"

--- a/source/encoders/codecs/prores.hpp
+++ b/source/encoders/codecs/prores.hpp
@@ -20,6 +20,7 @@
 // SOFTWARE.
 
 #pragma once
+#include "common.hpp"
 
 // Codec: ProRes
 #define P_PRORES "Codec.ProRes"
@@ -30,3 +31,21 @@
 #define P_PRORES_PROFILE_APCH "Codec.ProRes.Profile.APCH"
 #define P_PRORES_PROFILE_AP4H "Codec.ProRes.Profile.AP4H"
 #define P_PRORES_PROFILE_AP4X "Codec.ProRes.Profile.AP4X"
+
+namespace encoder::codec::prores {
+	enum class profile : std::int32_t {
+		APCO = 0,
+		Y422_PROXY = APCO,
+		APCS = 1,
+		Y422_LT = APCS,
+		APCN = 2,
+		Y422 = APCN,
+		APCH = 3,
+		Y422_HQ = APCH,
+		AP4H = 4,
+		Y4444 = AP4H,
+		AP4X = 5,
+		Y4444_XQ = AP4X,
+		_COUNT,
+	};
+}

--- a/source/encoders/ffmpeg-encoder.cpp
+++ b/source/encoders/ffmpeg-encoder.cpp
@@ -52,25 +52,24 @@ extern "C" {
 // FFmpeg
 #define ST_FFMPEG "FFmpegEncoder"
 #define ST_FFMPEG_CUSTOMSETTINGS "FFmpegEncoder.CustomSettings"
-#define ST_FFMPEG_THREADS "FFmpegEncoder.Threads"
-#define ST_FFMPEG_COLORFORMAT "FFmpegEncoder.ColorFormat"
-#define ST_FFMPEG_STANDARDCOMPLIANCE "FFmpegEncoder.StandardCompliance"
-#define ST_FFMPEG_GPU "FFmpegEncoder.GPU"
 #define KEY_FFMPEG_CUSTOMSETTINGS "FFmpeg.CustomSettings"
+#define ST_FFMPEG_THREADS "FFmpegEncoder.Threads"
 #define KEY_FFMPEG_THREADS "FFmpeg.Threads"
+#define ST_FFMPEG_COLORFORMAT "FFmpegEncoder.ColorFormat"
 #define KEY_FFMPEG_COLORFORMAT "FFmpeg.ColorFormat"
+#define ST_FFMPEG_STANDARDCOMPLIANCE "FFmpegEncoder.StandardCompliance"
 #define KEY_FFMPEG_STANDARDCOMPLIANCE "FFmpeg.StandardCompliance"
+#define ST_FFMPEG_GPU "FFmpegEncoder.GPU"
 #define KEY_FFMPEG_GPU "FFmpeg.GPU"
 
 #define ST_KEYFRAMES "FFmpegEncoder.KeyFrames"
 #define ST_KEYFRAMES_INTERVALTYPE "FFmpegEncoder.KeyFrames.IntervalType"
 #define ST_KEYFRAMES_INTERVALTYPE_(x) "FFmpegEncoder.KeyFrames.IntervalType." D_VSTR(x)
+#define KEY_KEYFRAMES_INTERVALTYPE "KeyFrames.IntervalType"
 #define ST_KEYFRAMES_INTERVAL "FFmpegEncoder.KeyFrames.Interval"
 #define ST_KEYFRAMES_INTERVAL_SECONDS "FFmpegEncoder.KeyFrames.Interval.Seconds"
-#define ST_KEYFRAMES_INTERVAL_FRAMES "FFmpegEncoder.KeyFrames.Interval.Frames"
-
-#define KEY_KEYFRAMES_INTERVALTYPE "KeyFrames.IntervalType"
 #define KEY_KEYFRAMES_INTERVAL_SECONDS "KeyFrames.Interval.Seconds"
+#define ST_KEYFRAMES_INTERVAL_FRAMES "FFmpegEncoder.KeyFrames.Interval.Frames"
 #define KEY_KEYFRAMES_INTERVAL_FRAMES "KeyFrames.Interval.Frames"
 
 using namespace encoder::ffmpeg;
@@ -95,7 +94,7 @@ ffmpeg_manager::~ffmpeg_manager()
 
 void ffmpeg_manager::register_handler(std::string codec, std::shared_ptr<handler::handler> handler)
 {
-	_handlers.try_emplace(codec, handler);
+	_handlers.emplace(codec, handler);
 }
 
 std::shared_ptr<handler::handler> ffmpeg_manager::get_handler(std::string codec)
@@ -619,7 +618,7 @@ void ffmpeg_instance::initialize_sw(obs_data_t* settings)
 
 		// Find a suitable Pixel Format.
 		AVPixelFormat _pixfmt_source = ::ffmpeg::tools::obs_videoformat_to_avpixelformat(voi->format);
-		AVPixelFormat _pixfmt_target = static_cast<AVPixelFormat>(obs_data_get_int(settings, ST_FFMPEG_COLORFORMAT));
+		AVPixelFormat _pixfmt_target = static_cast<AVPixelFormat>(obs_data_get_int(settings, KEY_FFMPEG_COLORFORMAT));
 		if (_pixfmt_target == AV_PIX_FMT_NONE) {
 			// Find the best conversion format.
 			_pixfmt_target = ::ffmpeg::tools::get_least_lossy_format(_codec->pix_fmts, _pixfmt_source);


### PR DESCRIPTION
### Description
Due to an oversight while renaming some defines, some encoders that did not support YUV 4:2:0 stopped working. With this they start working again.

### Motivation and Context
ProRes is currently broken as it tries to select YUV 4:2:0 always.

### How Has This Been Tested?
ProRes started working again.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
