### PR TITLE
cmake: Don't add lib prefix to binary files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -768,6 +768,12 @@ add_library(${PROJECT_NAME} MODULE
 	${PROJECT_PRIVATE}
 )
 
+set_target_properties(${PROJECT_NAME}
+	PROPERTIES
+		PREFIX ""
+		IMPORT_PREFIX ""
+)
+
 # Clang-Format
 if(HAVE_CLANG)
 	clang_format(


### PR DESCRIPTION
### Description
Removes the lib prefix, which is apparently not meant for shared modules/libraries that are plugins to something, but instead meant for global shared libraries. Makes no sense to me why this is different, and may be reverted in the future when StreamFX does start exporting other symbols again.

### Motivation and Context
Dunno, but it was requested in #135. Apparently breaks the FreeBSD ports framework.

### How Has This Been Tested?
Hasn't.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
- Breaking change (fix or feature that would cause existing functionality to change)
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
