### PR TITLE
cmake: Fix clang support in native OBS Studio build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,7 +75,7 @@ set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/clang" "${CMAKE_CURRENT
 
 # CMake Modules
 include("util")
-if(EXISTS "${CMAKE_SOURCE_DIR}/cmake/Clang/Clang.cmake")
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Clang/Clang.cmake")
 	include("Clang")
 	set(HAVE_CLANG ON)
 endif()

--- a/source/encoders/codecs/prores.hpp
+++ b/source/encoders/codecs/prores.hpp
@@ -34,18 +34,18 @@
 
 namespace encoder::codec::prores {
 	enum class profile : std::int32_t {
-		APCO = 0,
+		APCO       = 0,
 		Y422_PROXY = APCO,
-		APCS = 1,
-		Y422_LT = APCS,
-		APCN = 2,
-		Y422 = APCN,
-		APCH = 3,
-		Y422_HQ = APCH,
-		AP4H = 4,
-		Y4444 = AP4H,
-		AP4X = 5,
-		Y4444_XQ = AP4X,
+		APCS       = 1,
+		Y422_LT    = APCS,
+		APCN       = 2,
+		Y422       = APCN,
+		APCH       = 3,
+		Y422_HQ    = APCH,
+		AP4H       = 4,
+		Y4444      = AP4H,
+		AP4X       = 5,
+		Y4444_XQ   = AP4X,
 		_COUNT,
 	};
 }

--- a/source/encoders/handlers/nvenc_h264_handler.cpp
+++ b/source/encoders/handlers/nvenc_h264_handler.cpp
@@ -20,12 +20,12 @@
 // SOFTWARE.
 
 #include "nvenc_h264_handler.hpp"
+#include "strings.hpp"
 #include "../codecs/h264.hpp"
 #include "../ffmpeg-encoder.hpp"
 #include "ffmpeg/tools.hpp"
 #include "nvenc_shared.hpp"
 #include "plugin.hpp"
-#include "strings.hpp"
 #include "utility.hpp"
 
 extern "C" {

--- a/source/encoders/handlers/nvenc_hevc_handler.cpp
+++ b/source/encoders/handlers/nvenc_hevc_handler.cpp
@@ -20,12 +20,12 @@
 // SOFTWARE.
 
 #include "nvenc_hevc_handler.hpp"
+#include "strings.hpp"
 #include "../codecs/hevc.hpp"
 #include "../ffmpeg-encoder.hpp"
 #include "ffmpeg/tools.hpp"
 #include "nvenc_shared.hpp"
 #include "plugin.hpp"
-#include "strings.hpp"
 #include "utility.hpp"
 
 extern "C" {

--- a/source/encoders/handlers/nvenc_shared.cpp
+++ b/source/encoders/handlers/nvenc_shared.cpp
@@ -20,12 +20,12 @@
 // SOFTWARE.
 
 #include "nvenc_shared.hpp"
+#include "strings.hpp"
 #include <algorithm>
 #include "../codecs/hevc.hpp"
 #include "../ffmpeg-encoder.hpp"
 #include "ffmpeg/tools.hpp"
 #include "plugin.hpp"
-#include "strings.hpp"
 #include "utility.hpp"
 
 extern "C" {

--- a/source/filters/filter-blur.cpp
+++ b/source/filters/filter-blur.cpp
@@ -18,6 +18,7 @@
  */
 
 #include "filter-blur.hpp"
+#include "strings.hpp"
 #include <cfloat>
 #include <cinttypes>
 #include <cmath>
@@ -30,7 +31,6 @@
 #include "gfx/blur/gfx-blur-gaussian.hpp"
 #include "obs/gs/gs-helper.hpp"
 #include "obs/obs-source-tracker.hpp"
-#include "strings.hpp"
 #include "util-math.hpp"
 
 // OBS

--- a/source/filters/filter-color-grade.cpp
+++ b/source/filters/filter-color-grade.cpp
@@ -18,8 +18,8 @@
  */
 
 #include "filter-color-grade.hpp"
-#include <stdexcept>
 #include "strings.hpp"
+#include <stdexcept>
 #include "util-math.hpp"
 
 // OBS

--- a/source/filters/filter-color-grade.hpp
+++ b/source/filters/filter-color-grade.hpp
@@ -18,13 +18,13 @@
  */
 
 #pragma once
-#include "plugin.hpp"
 #include <vector>
 #include "obs/gs/gs-mipmapper.hpp"
 #include "obs/gs/gs-rendertarget.hpp"
 #include "obs/gs/gs-texture.hpp"
 #include "obs/gs/gs-vertexbuffer.hpp"
 #include "obs/obs-source-factory.hpp"
+#include "plugin.hpp"
 
 namespace filter::color_grade {
 	enum class detection_mode {

--- a/source/filters/filter-displacement.cpp
+++ b/source/filters/filter-displacement.cpp
@@ -18,9 +18,9 @@
 */
 
 #include "filter-displacement.hpp"
+#include "strings.hpp"
 #include <stdexcept>
 #include <sys/stat.h>
-#include "strings.hpp"
 
 #define ST "Filter.Displacement"
 #define ST_FILE "Filter.Displacement.File"

--- a/source/filters/filter-dynamic-mask.cpp
+++ b/source/filters/filter-dynamic-mask.cpp
@@ -18,9 +18,9 @@
 */
 
 #include "filter-dynamic-mask.hpp"
+#include "strings.hpp"
 #include <sstream>
 #include <stdexcept>
-#include "strings.hpp"
 
 // Filter to allow dynamic masking
 // Allow any channel to affect any other channel

--- a/source/filters/filter-sdf-effects.cpp
+++ b/source/filters/filter-sdf-effects.cpp
@@ -18,9 +18,9 @@
  */
 
 #include "filter-sdf-effects.hpp"
+#include "strings.hpp"
 #include <stdexcept>
 #include "obs/gs/gs-helper.hpp"
-#include "strings.hpp"
 
 #define LOG_PREFIX "<filter-sdf-effects> "
 

--- a/source/filters/filter-shader.cpp
+++ b/source/filters/filter-shader.cpp
@@ -18,9 +18,9 @@
  */
 
 #include "filter-shader.hpp"
+#include "strings.hpp"
 #include <stdexcept>
 #include "obs/gs/gs-helper.hpp"
-#include "strings.hpp"
 #include "utility.hpp"
 
 #define ST "Filter.Shader"

--- a/source/filters/filter-transform.cpp
+++ b/source/filters/filter-transform.cpp
@@ -18,10 +18,10 @@
  */
 
 #include "filter-transform.hpp"
+#include "strings.hpp"
 #include <algorithm>
 #include <stdexcept>
 #include "obs/gs/gs-helper.hpp"
-#include "strings.hpp"
 #include "util-math.hpp"
 
 // OBS

--- a/source/gfx/blur/gfx-blur-box-linear.cpp
+++ b/source/gfx/blur/gfx-blur-box-linear.cpp
@@ -27,8 +27,8 @@
 #pragma warning(push)
 #pragma warning(disable : 4201)
 #endif
-#include <obs-module.h>
 #include <obs.h>
+#include <obs-module.h>
 #ifdef _MSC_VER
 #pragma warning(pop)
 #endif

--- a/source/gfx/blur/gfx-blur-box.cpp
+++ b/source/gfx/blur/gfx-blur-box.cpp
@@ -27,8 +27,8 @@
 #pragma warning(push)
 #pragma warning(disable : 4201)
 #endif
-#include <obs-module.h>
 #include <obs.h>
+#include <obs-module.h>
 #ifdef _MSC_VER
 #pragma warning(pop)
 #endif

--- a/source/gfx/blur/gfx-blur-dual-filtering.cpp
+++ b/source/gfx/blur/gfx-blur-dual-filtering.cpp
@@ -25,8 +25,8 @@
 #pragma warning(push)
 #pragma warning(disable : 4201)
 #endif
-#include <obs-module.h>
 #include <obs.h>
+#include <obs-module.h>
 #ifdef _MSC_VER
 #pragma warning(pop)
 #endif

--- a/source/gfx/blur/gfx-blur-gaussian-linear.cpp
+++ b/source/gfx/blur/gfx-blur-gaussian-linear.cpp
@@ -24,8 +24,8 @@
 #pragma warning(push)
 #pragma warning(disable : 4201)
 #endif
-#include <obs-module.h>
 #include <obs.h>
+#include <obs-module.h>
 #ifdef _MSC_VER
 #pragma warning(pop)
 #endif

--- a/source/gfx/blur/gfx-blur-gaussian.cpp
+++ b/source/gfx/blur/gfx-blur-gaussian.cpp
@@ -25,8 +25,8 @@
 #pragma warning(push)
 #pragma warning(disable : 4201)
 #endif
-#include <obs-module.h>
 #include <obs.h>
+#include <obs-module.h>
 #ifdef _MSC_VER
 #pragma warning(pop)
 #endif

--- a/source/gfx/shader/gfx-shader-param-basic.cpp
+++ b/source/gfx/shader/gfx-shader-param-basic.cpp
@@ -16,11 +16,11 @@
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 
 #include "gfx-shader-param-basic.hpp"
+#include "strings.hpp"
 #include <algorithm>
 #include <map>
 #include <sstream>
 #include <stdexcept>
-#include "strings.hpp"
 
 #define ANNO_FIELD_TYPE "field_type"
 #define ANNO_SUFFIX "suffix"

--- a/source/gfx/shader/gfx-shader-param.hpp
+++ b/source/gfx/shader/gfx-shader-param.hpp
@@ -16,8 +16,8 @@
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 
 #pragma once
-#include <string>
 #include <list>
+#include <string>
 #include "obs/gs/gs-effect-parameter.hpp"
 
 namespace gfx {

--- a/source/nvidia/ar/nvidia-ar-feature.cpp
+++ b/source/nvidia/ar/nvidia-ar-feature.cpp
@@ -26,9 +26,7 @@ nvidia::ar::feature::feature(std::shared_ptr<::nvidia::ar::ar> ar, NvAR_FeatureI
 		throw std::runtime_error("Failed to create feature.");
 	}
 
-	_feature = std::shared_ptr<nvAR_Feature>{feat, [this](NvAR_FeatureHandle v) {
-		_ar->destroy(v);
-	}};
+	_feature = std::shared_ptr<nvAR_Feature>{feat, [this](NvAR_FeatureHandle v) { _ar->destroy(v); }};
 }
 
 nvidia::ar::feature::~feature()

--- a/source/nvidia/ar/nvidia-ar.hpp
+++ b/source/nvidia/ar/nvidia-ar.hpp
@@ -23,7 +23,6 @@
 #include <functional>
 #include <memory>
 
-
 #ifdef _MSC_VER
 #pragma warning(push)
 #pragma warning(disable : 4138)

--- a/source/nvidia/cuda/nvidia-cuda-context-stack.hpp
+++ b/source/nvidia/cuda/nvidia-cuda-context-stack.hpp
@@ -24,7 +24,7 @@
 
 namespace nvidia::cuda {
 	class context_stack {
-		std::shared_ptr<::nvidia::cuda::cuda>      _cuda;
+		std::shared_ptr<::nvidia::cuda::cuda>    _cuda;
 		std::shared_ptr<::nvidia::cuda::context> _ctx;
 
 		public:

--- a/source/nvidia/cuda/nvidia-cuda-context.cpp
+++ b/source/nvidia/cuda/nvidia-cuda-context.cpp
@@ -23,7 +23,7 @@
 #ifdef WIN32
 #ifdef _MSC_VER
 #pragma warning(push)
-#pragma warning(disable: 4191 4365 4777 5039 5204)
+#pragma warning(disable : 4191 4365 4777 5039 5204)
 #endif
 #include <atlutil.h>
 #ifdef _MSC_VER

--- a/source/nvidia/cuda/nvidia-cuda-memory.cpp
+++ b/source/nvidia/cuda/nvidia-cuda-memory.cpp
@@ -20,7 +20,8 @@
 #include "nvidia-cuda-memory.hpp"
 #include <stdexcept>
 
-nvidia::cuda::memory::memory(std::shared_ptr<::nvidia::cuda::cuda> cuda, std::size_t size) : _cuda(cuda), _pointer(), _size(size)
+nvidia::cuda::memory::memory(std::shared_ptr<::nvidia::cuda::cuda> cuda, std::size_t size)
+	: _cuda(cuda), _pointer(), _size(size)
 {
 	::nvidia::cuda::cu_result res = _cuda->cuMemAlloc(&_pointer, size);
 	switch (res) {

--- a/source/nvidia/cuda/nvidia-cuda-stream.hpp
+++ b/source/nvidia/cuda/nvidia-cuda-stream.hpp
@@ -18,13 +18,13 @@
  */
 
 #pragma once
-#include "nvidia-cuda.hpp"
 #include <memory>
+#include "nvidia-cuda.hpp"
 
 namespace nvidia::cuda {
 	class stream {
 		std::shared_ptr<::nvidia::cuda::cuda> _cuda;
-		::nvidia::cuda::cu_stream_t _stream;
+		::nvidia::cuda::cu_stream_t           _stream;
 
 		public:
 		stream(std::shared_ptr<::nvidia::cuda::cuda> cuda);

--- a/source/nvidia/cuda/nvidia-cuda.cpp
+++ b/source/nvidia/cuda/nvidia-cuda.cpp
@@ -90,20 +90,20 @@ nvidia::cuda::cuda::cuda()
 	CUDA_LOAD_SYMBOL_V2(cuMemcpyHtoAAsync);
 	CUDA_LOAD_SYMBOL_V2(cuMemcpyHtoD);
 	CUDA_LOAD_SYMBOL_V2(cuMemcpyHtoDAsync);
-	
-		// Stream Managment
+
+	// Stream Managment
 	CUDA_LOAD_SYMBOL(cuStreamCreate);
 	CUDA_LOAD_SYMBOL_V2(cuStreamDestroy);
 	CUDA_LOAD_SYMBOL(cuStreamSynchronize);
-	
-		// Graphics Interoperability
+
+	// Graphics Interoperability
 	CUDA_LOAD_SYMBOL(cuGraphicsMapResources);
 	CUDA_LOAD_SYMBOL(cuGraphicsSubResourceGetMappedArray);
 	CUDA_LOAD_SYMBOL(cuGraphicsUnmapResources);
 	CUDA_LOAD_SYMBOL(cuGraphicsUnregisterResource);
 
 #ifdef WIN32
-		// Direct3D11 Interopability
+	// Direct3D11 Interopability
 	CUDA_LOAD_SYMBOL(cuD3D11GetDevice);
 	CUDA_LOAD_SYMBOL(cuGraphicsD3D11RegisterResource);
 #endif

--- a/source/nvidia/cuda/nvidia-cuda.hpp
+++ b/source/nvidia/cuda/nvidia-cuda.hpp
@@ -82,8 +82,8 @@ namespace nvidia::cuda {
 	typedef void*         cu_stream_t;
 
 	struct cu_memcpy2d_t {
-		size_t          src_x_in_bytes;
-		size_t          src_y;
+		size_t src_x_in_bytes;
+		size_t src_y;
 
 		cu_memory_type  src_memory_type;
 		const void*     src_host;
@@ -91,8 +91,8 @@ namespace nvidia::cuda {
 		cu_array_t      src_array;
 		std::size_t     src_pitch;
 
-		size_t          dst_x_in_bytes;
-		size_t          dst_y;
+		size_t dst_x_in_bytes;
+		size_t dst_y;
 
 		cu_memory_type  dst_memory_type;
 		const void*     dst_host;
@@ -100,8 +100,8 @@ namespace nvidia::cuda {
 		cu_array_t      dst_array;
 		std::size_t     dst_pitch;
 
-		std::size_t     width_in_bytes;
-		std::size_t     height;
+		std::size_t width_in_bytes;
+		std::size_t height;
 	};
 
 	struct cu_array_descriptor_t {

--- a/source/sources/source-mirror.cpp
+++ b/source/sources/source-mirror.cpp
@@ -18,6 +18,7 @@
 */
 
 #include "source-mirror.hpp"
+#include "strings.hpp"
 #include <bitset>
 #include <cstring>
 #include <functional>
@@ -28,7 +29,6 @@
 #include "obs/gs/gs-helper.hpp"
 #include "obs/obs-source-tracker.hpp"
 #include "obs/obs-tools.hpp"
-#include "strings.hpp"
 
 // OBS
 #ifdef _MSC_VER

--- a/source/sources/source-shader.cpp
+++ b/source/sources/source-shader.cpp
@@ -18,16 +18,15 @@
  */
 
 #include "source-shader.hpp"
-#include <stdexcept>
 #include "strings.hpp"
+#include <stdexcept>
 #include "utility.hpp"
 
 #define ST "Source.Shader"
 
 using namespace source;
 
-shader::shader_instance::shader_instance(obs_data_t* data, obs_source_t* self)
-	: obs::source_instance(data, self), _fx()
+shader::shader_instance::shader_instance(obs_data_t* data, obs_source_t* self) : obs::source_instance(data, self), _fx()
 {
 	_fx = std::make_shared<gfx::shader::shader>(self, gfx::shader::shader_mode::Source);
 

--- a/source/transitions/transition-shader.cpp
+++ b/source/transitions/transition-shader.cpp
@@ -17,9 +17,9 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
  */
 
-#include "transition-shader.hpp"
-#include <stdexcept>
 #include "strings.hpp"
+#include <stdexcept>
+#include "transition-shader.hpp"
 #include "utility.hpp"
 
 #define ST "Transition.Shader"

--- a/source/util-event.hpp
+++ b/source/util-event.hpp
@@ -18,10 +18,10 @@
  */
 
 #pragma once
+#include "common.hpp"
 #include <functional>
 #include <list>
 #include <mutex>
-#include "common.hpp"
 
 namespace util {
 	template<typename... _args>


### PR DESCRIPTION
### Description
Fixes clang-format support when built together with OBS Studio. 

### Motivation and Context
Clang-Format wasn't working at all when building together with OBS Studio

### How Has This Been Tested?
Clang-Format automatically formatted all files again when building together with OBS Studio.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
