### PR TITLE
obs-source-factory: Add settings migration code

### DIFF
--- a/source/filters/filter-blur.cpp
+++ b/source/filters/filter-blur.cpp
@@ -197,14 +197,16 @@ bool blur::blur_instance::apply_mask_parameters(gs::effect effect, gs_texture_t*
 	return true;
 }
 
-inline void migrate_settings(obs_data_t* settings)
+void blur::blur_instance::load(obs_data_t* settings)
 {
-	obs_data_set_default_int(settings, S_VERSION, -1);
-	int64_t version = obs_data_get_int(settings, S_VERSION);
+	update(settings);
+}
 
+void filter::blur::blur_instance::migrate(obs_data_t* settings, std::uint64_t version)
+{
 	// Now we use a fall-through switch to gradually upgrade each known version change.
 	switch (version) {
-	case -1:
+	case 0:
 		/// Blur Type
 		int64_t old_blur = obs_data_get_int(settings, "Filter.Blur.Type");
 		if (old_blur == 0) { // Box
@@ -236,15 +238,10 @@ inline void migrate_settings(obs_data_t* settings)
 		obs_data_set_double(settings, ST_ANGLE, angle);
 		obs_data_unset_user_value(settings, "Filter.Blur.Directional.Angle");
 	}
-
-	obs_data_set_int(settings, S_VERSION, STREAMFX_VERSION);
 }
 
 void blur::blur_instance::update(obs_data_t* settings)
 {
-	// Ensure backwards compatibility.
-	migrate_settings(settings);
-
 	{ // Blur Type
 		const char* blur_type      = obs_data_get_string(settings, ST_TYPE);
 		const char* blur_subtype   = obs_data_get_string(settings, ST_SUBTYPE);
@@ -307,11 +304,6 @@ void blur::blur_instance::update(obs_data_t* settings)
 			}
 		}
 	}
-}
-
-void blur::blur_instance::load(obs_data_t* settings)
-{
-	update(settings);
 }
 
 void blur::blur_instance::video_tick(float)

--- a/source/filters/filter-blur.hpp
+++ b/source/filters/filter-blur.hpp
@@ -99,8 +99,9 @@ namespace filter::blur {
 		~blur_instance();
 
 		public:
-		virtual void update(obs_data_t* settings) override;
 		virtual void load(obs_data_t* settings) override;
+		virtual void migrate(obs_data_t* settings, std::uint64_t version) override;
+		virtual void update(obs_data_t* settings) override;
 
 		virtual void video_tick(float time) override;
 		virtual void video_render(gs_effect_t* effect) override;

--- a/source/filters/filter-color-grade.cpp
+++ b/source/filters/filter-color-grade.cpp
@@ -128,6 +128,8 @@ void color_grade::color_grade_instance::load(obs_data_t* data)
 	update(data);
 }
 
+void filter::color_grade::color_grade_instance::migrate(obs_data_t* data, std::uint64_t version) {}
+
 void color_grade::color_grade_instance::update(obs_data_t* data)
 {
 	_lift.x         = static_cast<float_t>(obs_data_get_double(data, ST_LIFT_(RED)) / 100.0);

--- a/source/filters/filter-color-grade.hpp
+++ b/source/filters/filter-color-grade.hpp
@@ -72,6 +72,7 @@ namespace filter::color_grade {
 		virtual ~color_grade_instance();
 
 		virtual void load(obs_data_t* data) override;
+		virtual void migrate(obs_data_t* data, std::uint64_t version) override;
 		virtual void update(obs_data_t* data) override;
 
 		virtual void video_tick(float time) override;

--- a/source/filters/filter-displacement.cpp
+++ b/source/filters/filter-displacement.cpp
@@ -54,27 +54,20 @@ void displacement::displacement_instance::load(obs_data_t* settings)
 	update(settings);
 }
 
-inline void migrate_settings(obs_data_t* settings)
+void filter::displacement::displacement_instance::migrate(obs_data_t* data, std::uint64_t version)
 {
-	uint64_t version = static_cast<uint64_t>(obs_data_get_int(settings, S_VERSION));
-
 	switch (version & STREAMFX_MASK_COMPAT) {
 	case 0:
-		obs_data_set_double(settings, ST_SCALE, obs_data_get_double(settings, "Filter.Displacement.Scale") * 0.5);
-		obs_data_set_double(settings, ST_SCALE_TYPE,
-							obs_data_get_double(settings, "Filter.Displacement.Ratio") * 100.0);
-		obs_data_unset_user_value(settings, "Filter.Displacement.Ratio");
+		obs_data_set_double(data, ST_SCALE, obs_data_get_double(data, "Filter.Displacement.Scale") * 0.5);
+		obs_data_set_double(data, ST_SCALE_TYPE, obs_data_get_double(data, "Filter.Displacement.Ratio") * 100.0);
+		obs_data_unset_user_value(data, "Filter.Displacement.Ratio");
 	case STREAMFX_MAKE_VERSION(0, 8, 0, 0):
 		break;
 	}
-
-	obs_data_set_int(settings, S_VERSION, STREAMFX_VERSION);
 }
 
 void displacement::displacement_instance::update(obs_data_t* settings)
 {
-	migrate_settings(settings);
-
 	_scale[0] = _scale[1] = static_cast<float_t>(obs_data_get_double(settings, ST_SCALE));
 	_scale_type           = static_cast<float_t>(obs_data_get_double(settings, ST_SCALE_TYPE) / 100.0);
 

--- a/source/filters/filter-displacement.hpp
+++ b/source/filters/filter-displacement.hpp
@@ -41,6 +41,7 @@ namespace filter::displacement {
 		virtual ~displacement_instance();
 
 		virtual void load(obs_data_t* settings) override;
+		virtual void migrate(obs_data_t* data, std::uint64_t version) override;
 		virtual void update(obs_data_t* settings) override;
 
 		virtual void video_tick(float_t) override;

--- a/source/filters/filter-dynamic-mask.cpp
+++ b/source/filters/filter-dynamic-mask.cpp
@@ -74,6 +74,13 @@ dynamic_mask::dynamic_mask_instance::dynamic_mask_instance(obs_data_t* settings,
 
 dynamic_mask::dynamic_mask_instance::~dynamic_mask_instance() {}
 
+void dynamic_mask::dynamic_mask_instance::load(obs_data_t* settings)
+{
+	update(settings);
+}
+
+void filter::dynamic_mask::dynamic_mask_instance::migrate(obs_data_t* data, std::uint64_t version) {}
+
 void dynamic_mask::dynamic_mask_instance::update(obs_data_t* settings)
 {
 	// Update source.
@@ -133,11 +140,6 @@ void dynamic_mask::dynamic_mask_instance::update(obs_data_t* settings)
 			ch->ptr[static_cast<size_t>(kv2.first)] = found->second.values.ptr[static_cast<size_t>(kv2.first)];
 		}
 	}
-}
-
-void dynamic_mask::dynamic_mask_instance::load(obs_data_t* settings)
-{
-	update(settings);
 }
 
 void dynamic_mask::dynamic_mask_instance::save(obs_data_t* settings)

--- a/source/filters/filter-dynamic-mask.hpp
+++ b/source/filters/filter-dynamic-mask.hpp
@@ -65,8 +65,9 @@ namespace filter::dynamic_mask {
 		dynamic_mask_instance(obs_data_t* data, obs_source_t* self);
 		virtual ~dynamic_mask_instance();
 
-		virtual void update(obs_data_t* settings) override;
 		virtual void load(obs_data_t* settings) override;
+		virtual void migrate(obs_data_t* data, std::uint64_t version) override;
+		virtual void update(obs_data_t* settings) override;
 		virtual void save(obs_data_t* settings) override;
 
 		void input_renamed(obs::deprecated_source* src, std::string old_name, std::string new_name);

--- a/source/filters/filter-nv-face-tracking.cpp
+++ b/source/filters/filter-nv-face-tracking.cpp
@@ -195,6 +195,8 @@ void filter::nvidia::face_tracking_instance::load(obs_data_t* data)
 	update(data);
 }
 
+void filter::nvidia::face_tracking_instance::migrate(obs_data_t* data, std::uint64_t version) {}
+
 void filter::nvidia::face_tracking_instance::update(obs_data_t* data)
 {
 	_cfg_roi_zoom          = obs_data_get_double(data, SK_ROI_ZOOM) / 100.0;

--- a/source/filters/filter-nv-face-tracking.hpp
+++ b/source/filters/filter-nv-face-tracking.hpp
@@ -101,6 +101,8 @@ namespace filter::nvidia {
 
 		virtual void load(obs_data_t* data) override;
 
+		virtual void migrate(obs_data_t* data, std::uint64_t version) override;
+
 		virtual void update(obs_data_t* data) override;
 
 		virtual void video_tick(float seconds) override;

--- a/source/filters/filter-sdf-effects.cpp
+++ b/source/filters/filter-sdf-effects.cpp
@@ -119,6 +119,13 @@ sdf_effects::sdf_effects_instance::sdf_effects_instance(obs_data_t* settings, ob
 
 sdf_effects::sdf_effects_instance::~sdf_effects_instance() {}
 
+void sdf_effects::sdf_effects_instance::load(obs_data_t* settings)
+{
+	update(settings);
+}
+
+void filter::sdf_effects::sdf_effects_instance::migrate(obs_data_t* data, std::uint64_t version) {}
+
 void sdf_effects::sdf_effects_instance::update(obs_data_t* data)
 {
 	{
@@ -252,11 +259,6 @@ void sdf_effects::sdf_effects_instance::update(obs_data_t* data)
 
 	_sdf_scale     = double_t(obs_data_get_double(data, ST_SDF_SCALE) / 100.0);
 	_sdf_threshold = float_t(obs_data_get_double(data, ST_SDF_THRESHOLD) / 100.0);
-}
-
-void sdf_effects::sdf_effects_instance::load(obs_data_t* settings)
-{
-	update(settings);
 }
 
 void sdf_effects::sdf_effects_instance::video_tick(float)

--- a/source/filters/filter-sdf-effects.hpp
+++ b/source/filters/filter-sdf-effects.hpp
@@ -85,8 +85,9 @@ namespace filter::sdf_effects {
 		sdf_effects_instance(obs_data_t* settings, obs_source_t* self);
 		virtual ~sdf_effects_instance();
 
-		virtual void update(obs_data_t* settings) override;
 		virtual void load(obs_data_t* settings) override;
+		virtual void migrate(obs_data_t* data, std::uint64_t version) override;
+		virtual void update(obs_data_t* settings) override;
 
 		virtual void video_tick(float) override;
 		virtual void video_render(gs_effect_t*) override;

--- a/source/filters/filter-shader.cpp
+++ b/source/filters/filter-shader.cpp
@@ -55,6 +55,8 @@ void filter::shader::shader_instance::load(obs_data_t* data)
 	update(data);
 }
 
+void filter::shader::shader_instance::migrate(obs_data_t* data, std::uint64_t version) {}
+
 void filter::shader::shader_instance::update(obs_data_t* data)
 {
 	_fx->update(data);

--- a/source/filters/filter-shader.hpp
+++ b/source/filters/filter-shader.hpp
@@ -38,6 +38,7 @@ namespace filter::shader {
 		void properties(obs_properties_t* props);
 
 		virtual void load(obs_data_t* data) override;
+		virtual void migrate(obs_data_t* data, std::uint64_t version) override;
 		virtual void update(obs_data_t* data) override;
 
 		virtual void video_tick(float_t sec_since_last) override;

--- a/source/filters/filter-transform.cpp
+++ b/source/filters/filter-transform.cpp
@@ -113,23 +113,18 @@ transform::transform_instance::~transform_instance()
 	_mipmap_texture.reset();
 }
 
-inline void migrate_settings(obs_data_t* settings)
-{
-	uint64_t version = static_cast<uint64_t>(obs_data_get_int(settings, S_VERSION));
-
-	switch (version & STREAMFX_MASK_COMPAT) {
-	case 0:
-		obs_data_set_double(settings, ST_ROTATION_X, -obs_data_get_double(settings, ST_ROTATION_X));
-		obs_data_set_double(settings, ST_ROTATION_Y, -obs_data_get_double(settings, ST_ROTATION_Y));
-	}
-
-	obs_data_set_int(settings, S_VERSION, STREAMFX_VERSION);
-}
-
 void transform::transform_instance::load(obs_data_t* settings)
 {
-	migrate_settings(settings);
 	update(settings);
+}
+
+void filter::transform::transform_instance::migrate(obs_data_t* data, std::uint64_t version)
+{
+	switch (version & STREAMFX_MASK_COMPAT) {
+	case 0:
+		obs_data_set_double(data, ST_ROTATION_X, -obs_data_get_double(data, ST_ROTATION_X));
+		obs_data_set_double(data, ST_ROTATION_Y, -obs_data_get_double(data, ST_ROTATION_Y));
+	}
 }
 
 void transform::transform_instance::update(obs_data_t* settings)

--- a/source/filters/filter-transform.hpp
+++ b/source/filters/filter-transform.hpp
@@ -65,6 +65,7 @@ namespace filter::transform {
 		virtual ~transform_instance() override;
 
 		virtual void load(obs_data_t* settings) override;
+		virtual void migrate(obs_data_t* data, std::uint64_t version) override;
 		virtual void update(obs_data_t*) override;
 
 		virtual void video_tick(float) override;

--- a/source/sources/source-mirror.cpp
+++ b/source/sources/source-mirror.cpp
@@ -91,10 +91,13 @@ uint32_t mirror::mirror_instance::get_height()
 	return _source_size.second;
 }
 
-static void convert_config(obs_data_t* data)
+void mirror::mirror_instance::load(obs_data_t* data)
 {
-	uint64_t version = static_cast<uint64_t>(obs_data_get_int(data, S_VERSION));
+	update(data);
+}
 
+void source::mirror::mirror_instance::migrate(obs_data_t* data, std::uint64_t version)
+{
 	switch (version) {
 	case 0:
 		obs_data_set_int(data, ST_SOURCE_AUDIO_LAYOUT, obs_data_get_int(data, "Source.Mirror.Audio.Layout"));
@@ -102,26 +105,16 @@ static void convert_config(obs_data_t* data)
 	case STREAMFX_VERSION:
 		break;
 	}
-
-	obs_data_set_int(data, S_VERSION, STREAMFX_VERSION);
-	obs_data_set_string(data, S_COMMIT, STREAMFX_COMMIT);
 }
 
 void mirror::mirror_instance::update(obs_data_t* data)
 {
-	convert_config(data);
-
 	// Audio
 	_audio_enabled = obs_data_get_bool(data, ST_SOURCE_AUDIO);
 	_audio_layout  = static_cast<speaker_layout>(obs_data_get_int(data, ST_SOURCE_AUDIO_LAYOUT));
 
 	// Acquire new source.
 	acquire(obs_data_get_string(data, ST_SOURCE));
-}
-
-void mirror::mirror_instance::load(obs_data_t* data)
-{
-	update(data);
 }
 
 void mirror::mirror_instance::save(obs_data_t* data)

--- a/source/sources/source-mirror.hpp
+++ b/source/sources/source-mirror.hpp
@@ -61,8 +61,9 @@ namespace source::mirror {
 		virtual uint32_t get_width() override;
 		virtual uint32_t get_height() override;
 
-		virtual void update(obs_data_t*) override;
 		virtual void load(obs_data_t*) override;
+		virtual void migrate(obs_data_t*, std::uint64_t) override;
+		virtual void update(obs_data_t*) override;
 		virtual void save(obs_data_t*) override;
 
 		virtual void video_tick(float) override;


### PR DESCRIPTION
### Description
Previously sources had to manually implement migration code, which resulted in unresolvable regression issues due to the lack of version and commit tagging. With the new migration code, all sources automatically have this version and commit tagging at all times, and as such can now have a temporary regression fixed without the user needing to change any values manually.

### How Has This Been Tested?
Testing in progress.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
