### PR TITLE
Nvidia Face Tracking: Convert to asynchronous threaded tracking

### DIFF
--- a/source/nvidia/cuda/nvidia-cuda-context.cpp
+++ b/source/nvidia/cuda/nvidia-cuda-context.cpp
@@ -70,6 +70,9 @@ nvidia::cuda::context::context(std::shared_ptr<::nvidia::cuda::cuda> cuda, ID3D1
 	if (cu_result res = _cuda->cuDevicePrimaryCtxRetain(&_ctx, _device); res != cu_result::SUCCESS) {
 		throw std::runtime_error("Failed to acquire primary device context.");
 	}
+
+	_cuda->cuDevicePrimaryCtxSetFlags(_device, cu_context_flags::SCHEDULER_YIELD);
+
 	_has_device = true;
 }
 #endif

--- a/source/nvidia/cuda/nvidia-cuda-gs-texture.cpp
+++ b/source/nvidia/cuda/nvidia-cuda-gs-texture.cpp
@@ -28,8 +28,8 @@ nvidia::cuda::gstexture::gstexture(std::shared_ptr<nvidia::cuda::cuda> cuda, std
 	if (!cuda)
 		throw std::invalid_argument("cuda");
 
-	auto gtc      = gs::context{};
-	int  dev_type = gs_get_device_type();
+	gs::context gctx;
+	int         dev_type = gs_get_device_type();
 
 	if (dev_type == GS_DEVICE_OPENGL) {
 		// ToDo

--- a/source/nvidia/cuda/nvidia-cuda-stream.cpp
+++ b/source/nvidia/cuda/nvidia-cuda-stream.cpp
@@ -20,9 +20,16 @@
 #include "nvidia-cuda-stream.hpp"
 #include <stdexcept>
 
-nvidia::cuda::stream::stream(std::shared_ptr<::nvidia::cuda::cuda> cuda) : _cuda(cuda)
+nvidia::cuda::stream::stream(std::shared_ptr<::nvidia::cuda::cuda> cuda, ::nvidia::cuda::cu_stream_flags flags,
+							 std::int32_t priority)
+	: _cuda(cuda)
 {
-	nvidia::cuda::cu_result res = _cuda->cuStreamCreate(&_stream, 0);
+	nvidia::cuda::cu_result res;
+	if (priority == 0) {
+		res = _cuda->cuStreamCreate(&_stream, flags);
+	} else {
+		res = _cuda->cuStreamCreateWithPriority(&_stream, flags, priority);
+	}
 	switch (res) {
 	case nvidia::cuda::cu_result::SUCCESS:
 		break;

--- a/source/nvidia/cuda/nvidia-cuda-stream.hpp
+++ b/source/nvidia/cuda/nvidia-cuda-stream.hpp
@@ -27,7 +27,9 @@ namespace nvidia::cuda {
 		::nvidia::cuda::cu_stream_t           _stream;
 
 		public:
-		stream(std::shared_ptr<::nvidia::cuda::cuda> cuda);
+		stream(std::shared_ptr<::nvidia::cuda::cuda> cuda,
+			   ::nvidia::cuda::cu_stream_flags       flags    = ::nvidia::cuda::cu_stream_flags::DEFAULT,
+			   std::int32_t                          priority = 0);
 		~stream();
 
 		::nvidia::cuda::cu_stream_t get();

--- a/source/nvidia/cuda/nvidia-cuda.cpp
+++ b/source/nvidia/cuda/nvidia-cuda.cpp
@@ -61,10 +61,12 @@ nvidia::cuda::cuda::cuda()
 	// Primary Context Management
 	CUDA_LOAD_SYMBOL(cuDevicePrimaryCtxRetain);
 	CUDA_LOAD_SYMBOL_V2(cuDevicePrimaryCtxRelease);
+	CUDA_LOAD_SYMBOL_V2(cuDevicePrimaryCtxSetFlags);
 
 	// Context Management
 	CUDA_LOAD_SYMBOL_V2(cuCtxDestroy);
 	CUDA_LOAD_SYMBOL(cuCtxGetCurrent);
+	CUDA_LOAD_SYMBOL(cuCtxGetStreamPriorityRange);
 	CUDA_LOAD_SYMBOL_V2(cuCtxPopCurrent);
 	CUDA_LOAD_SYMBOL_V2(cuCtxPushCurrent);
 	CUDA_LOAD_SYMBOL(cuCtxSetCurrent);
@@ -93,6 +95,7 @@ nvidia::cuda::cuda::cuda()
 
 	// Stream Managment
 	CUDA_LOAD_SYMBOL(cuStreamCreate);
+	CUDA_LOAD_SYMBOL(cuStreamCreateWithPriority);
 	CUDA_LOAD_SYMBOL_V2(cuStreamDestroy);
 	CUDA_LOAD_SYMBOL(cuStreamSynchronize);
 

--- a/source/nvidia/cuda/nvidia-cuda.hpp
+++ b/source/nvidia/cuda/nvidia-cuda.hpp
@@ -21,6 +21,7 @@
 #include <cstddef>
 #include <functional>
 #include <memory>
+#include "utility.hpp"
 
 #ifdef WIN32
 #pragma warning(push)
@@ -75,11 +76,26 @@ namespace nvidia::cuda {
 		FLOAT          = 0b00100000,
 	};
 
+	enum class cu_context_flags : std::uint32_t {
+		SCHEDULER_AUTO                 = 0x0,
+		SCHEDULER_SPIN                 = 0x1,
+		SCHEDULER_YIELD                = 0x2,
+		SCHEDULER_BLOCKING_SYNC        = 0x4,
+		MAP_HOST                       = 0x8,
+		LOCAL_MEMORY_RESIZE_TO_MAXIMUM = 0x10,
+	};
+
+	enum class cu_stream_flags : std::uint32_t {
+		DEFAULT      = 0x0,
+		NON_BLOCKING = 0x1,
+	};
+
 	typedef void*         cu_array_t;
 	typedef void*         cu_context_t;
 	typedef std::uint64_t cu_device_ptr_t;
 	typedef void*         cu_graphics_resource_t;
 	typedef void*         cu_stream_t;
+	typedef std::int32_t  cu_device_t;
 
 	struct cu_memcpy2d_t {
 		std::size_t src_x_in_bytes;
@@ -138,10 +154,10 @@ namespace nvidia::cuda {
 
 		// Primary Context Management
 		// cuDevicePrimaryCtxGetState
-		CUDA_DEFINE_FUNCTION(cuDevicePrimaryCtxRelease, std::int32_t device);
+		CUDA_DEFINE_FUNCTION(cuDevicePrimaryCtxRelease, cu_device_t device);
 		// cuDevicePrimaryCtxReset_v2
-		CUDA_DEFINE_FUNCTION(cuDevicePrimaryCtxRetain, cu_context_t* ctx, std::int32_t device);
-		// cuDevicePrimaryCtxSetFlags_v2
+		CUDA_DEFINE_FUNCTION(cuDevicePrimaryCtxRetain, cu_context_t* ctx, cu_device_t device);
+		CUDA_DEFINE_FUNCTION(cuDevicePrimaryCtxSetFlags, cu_device_t device, cu_context_flags flags);
 
 		// Context Management
 		// cuCtxCreate_v2
@@ -153,7 +169,7 @@ namespace nvidia::cuda {
 		// cuCtxGetFlags
 		// cuCtxGetLimit
 		// cuCtxGetSharedMemConfig
-		// cuCtxGetStreamPriorityRange
+		CUDA_DEFINE_FUNCTION(cuCtxGetStreamPriorityRange, std::int32_t* lowestPriority, std::int32_t* highestPriority);
 		CUDA_DEFINE_FUNCTION(cuCtxPopCurrent, cu_context_t* ctx);
 		CUDA_DEFINE_FUNCTION(cuCtxPushCurrent, cu_context_t ctx);
 		// cuCtxSetCacheConfig
@@ -278,8 +294,9 @@ namespace nvidia::cuda {
 		// cuStreamAddCallback
 		// cuStreamAttachMemAsync
 		// cuStreamBeginCapture_v2
-		CUDA_DEFINE_FUNCTION(cuStreamCreate, cu_stream_t* stream, std::uint32_t flags);
-		// cuStreamCreateWithPriority
+		CUDA_DEFINE_FUNCTION(cuStreamCreate, cu_stream_t* stream, cu_stream_flags flags);
+		CUDA_DEFINE_FUNCTION(cuStreamCreateWithPriority, cu_stream_t* stream, cu_stream_flags flags,
+							 std::int32_t priority);
 		CUDA_DEFINE_FUNCTION(cuStreamDestroy, cu_stream_t stream);
 		// cuStreamEndCapture
 		// cuStreamGetCaptureInfo
@@ -385,3 +402,6 @@ namespace nvidia::cuda {
 #endif
 	};
 } // namespace nvidia::cuda
+
+P_ENABLE_BITMASK_OPERATORS(::nvidia::cuda::cu_context_flags)
+P_ENABLE_BITMASK_OPERATORS(::nvidia::cuda::cu_stream_flags)

--- a/source/obs/gs/gs-helper.hpp
+++ b/source/obs/gs/gs-helper.hpp
@@ -29,11 +29,30 @@ namespace gs {
 		~context();
 	};
 
-	static const float_t debug_color_source[4]       = {0.f, .5f, 5.f, 1.f};
-	static const float_t debug_color_cache[4]        = {1.f, .75f, 0.f, 1.f};
-	static const float_t debug_color_cache_render[4] = {.2f, .15f, 0.f, 1.f};
-	static const float_t debug_color_convert[4]      = {.5f, .5f, 0.5f, 1.f};
-	static const float_t debug_color_render[4]       = {0.f, 1.f, 0.0f, 1.f};
+	static const float_t debug_color_white[4]           = {1.f, 1.f, 1.f, 1.f};
+	static const float_t debug_color_gray[4]            = {.5f, .5f, .5f, 1.f};
+	static const float_t debug_color_black[4]           = {0.f, 0.f, 0.f, 1.f};
+	static const float_t debug_color_red[4]             = {1.f, 0.f, 0.f, 1.f};
+	static const float_t debug_color_flush_orange[4]    = {1.f, .5f, 0.f, 1.f};
+	static const float_t debug_color_yellow[4]          = {1.f, 1.f, 0.f, 1.f};
+	static const float_t debug_color_chartreuse[4]      = {.5f, 1.f, 0.f, 1.f};
+	static const float_t debug_color_green[4]           = {0.f, 1.f, 0.f, 1.f};
+	static const float_t debug_color_spring_green[4]    = {0.f, 1.f, .5f, 1.f};
+	static const float_t debug_color_teal[4]            = {0.f, 1.f, 1.f, 1.f};
+	static const float_t debug_color_azure_radiance[4]  = {0.f, .5f, 1.f, 1.f};
+	static const float_t debug_color_blue[4]            = {0.f, 0.f, 1.f, 1.f};
+	static const float_t debug_color_electric_violet[4] = {.5f, 0.f, 1.f, 1.f};
+	static const float_t debug_color_magenta[4]         = {1.f, 0.f, 1.f, 1.f};
+	static const float_t debug_color_rose[4]            = {1.f, 0.f, .5f, 1.f};
+
+	static const float_t* debug_color_source       = debug_color_white;
+	static const float_t* debug_color_capture      = debug_color_flush_orange;
+	static const float_t* debug_color_cache        = debug_color_capture;
+	static const float_t* debug_color_convert      = debug_color_electric_violet;
+	static const float_t* debug_color_cache_render = debug_color_convert;
+	static const float_t* debug_color_copy         = debug_color_azure_radiance;
+	static const float_t* debug_color_allocate     = debug_color_red;
+	static const float_t* debug_color_render       = debug_color_teal;
 
 	class debug_marker {
 		std::string _name;

--- a/source/obs/obs-tools.hpp
+++ b/source/obs/obs-tools.hpp
@@ -43,6 +43,11 @@ namespace obs {
 		obs_source_release(v);
 	}
 
+	inline void obs_weak_source_deleter(obs_weak_source_t* v)
+	{
+		obs_weak_source_release(v);
+	}
+
 	inline void obs_scene_deleter(obs_scene_t* v)
 	{
 		obs_scene_release(v);

--- a/source/util-threadpool.cpp
+++ b/source/util-threadpool.cpp
@@ -51,15 +51,15 @@ void util::threadpool::push(threadpool_function_t fn, std::shared_ptr<void> data
 
 void util::threadpool::work()
 {
-	std::pair<threadpool_function_t, std::shared_ptr<void>> work;
-
 	while (!_worker_stop) {
+		std::pair<threadpool_function_t, std::shared_ptr<void>> work;
+
 		// Wait for more work, or immediately continue if there is still work to do.
 		{
 			std::unique_lock<std::mutex> lock(_tasks_lock);
 			if (_tasks.size() == 0)
 				_tasks_cv.wait(lock, [this]() { return _worker_stop || _tasks.size() > 0; });
-			if (_tasks.size() == 0)
+			if (_worker_stop || (_tasks.size() == 0))
 				continue;
 			work = _tasks.front();
 			_tasks.pop_front();


### PR DESCRIPTION
<!-- Hi, thank you for taking the time to submit a pull request. -->
<!-- Please make sure that you fill this out in it's entirety. -->

### Description
<!-- Describe your changes in as much detail as possible. -->
<!-- But please exclude your personal history from this. Only describe the changes -->
Through the use of asynchronous threaded tracking, the filter can gain some performance and free up render time in libOBS. Additionally increasing the CUDA stream priority prevents other GPU users from overpowering our request to use resources.

### Related Issues
- #150 Performance trouble with Nvidia Face Tracking
<!-- - #0001 Name of Issue -->
