### PR TITLE
cmake: Add support for running clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,35 @@
+Checks:          '-*,clang-diagnostic-*,clang-analyzer-*,cppcoreguidelines-*,portability-*,readability-*,performance-*'
+WarningsAsErrors: ''
+HeaderFilterRegex: ''
+AnalyzeTemporaryDtors: false
+FormatStyle:     none
+User:            Xaymar
+CheckOptions:
+  - key:             cert-dcl16-c.NewSuffixes
+    value:           'L;LL;LU;LLU'
+  - key:             cert-oop54-cpp.WarnOnlyIfThisHasSuspiciousField
+    value:           '0'
+  - key:             cppcoreguidelines-explicit-virtual-functions.IgnoreDestructors
+    value:           '1'
+  - key:             cppcoreguidelines-non-private-member-variables-in-classes.IgnoreClassesWithAllMemberVariablesBeingPublic
+    value:           '1'
+  - key:             google-readability-braces-around-statements.ShortStatementLines
+    value:           '1'
+  - key:             google-readability-function-size.StatementThreshold
+    value:           '800'
+  - key:             google-readability-namespace-comments.ShortNamespaceLines
+    value:           '10'
+  - key:             google-readability-namespace-comments.SpacesBeforeComments
+    value:           '2'
+  - key:             modernize-loop-convert.MaxCopySize
+    value:           '16'
+  - key:             modernize-loop-convert.MinConfidence
+    value:           reasonable
+  - key:             modernize-loop-convert.NamingStyle
+    value:           CamelCase
+  - key:             modernize-pass-by-value.IncludeStyle
+    value:           llvm
+  - key:             modernize-replace-auto-ptr.IncludeStyle
+    value:           llvm
+  - key:             modernize-use-nullptr.NullMacros
+    value:           'NULL'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -909,6 +909,7 @@ set_target_properties(
 	${PROJECT_NAME}
 	PROPERTIES
 		CXX_STANDARD ${_CXX_STANDARD}
+		CXX_STANDARD_REQUIRED ON
 		CXX_EXTENSIONS ${_CXX_EXTENSIONS}
 )
 
@@ -947,8 +948,15 @@ if(HAVE_OBS_FRONTEND)
 	)
 endif()
 
-# Clang-Format
+# Clang Tools
 if(HAVE_CLANG)
+	generate_compile_commands_json(
+		TARGETS ${PROJECT_NAME}
+	)
+	clang_tidy(
+		TARGETS ${PROJECT_NAME}		
+		VERSION 9.0.0
+	)
 	clang_format(
 		TARGETS ${PROJECT_NAME}
 		DEPENDENCY


### PR DESCRIPTION
<!-- Hi, thank you for taking the time to submit a pull request. -->
<!-- Please make sure that you fill this out in it's entirety. -->

### Description
As shown earlier in #115, a static analyzer can show code problems that would otherwise be left undetected. `clang-tidy` is a perfect candidate for this as it comes bundled with the clang toolset, and is by far the most advanced static analyzer that is available for free. Additionally since it is cross-platform it enables it to be used everywhere.

This adds it to the CMake projects as StreamFX_CLANG-TIDY so that it can simple be "built" by cmake. The script first generated compile_commands.json for each build configuration, which are then used by clang-tidy later on.

### Related Issues
<!-- - #0000 Name of Issue -->
<!-- - #0001 Name of Issue -->
