### PR TITLE
common: Undefine the unsafe 'strtoll' define from libobs

### DIFF
--- a/source/common.hpp
+++ b/source/common.hpp
@@ -70,6 +70,10 @@ extern "C" {
 #include <graphics/vec4.h>
 
 #include <util/platform.h>
+
+// Fix libOBS's global defines
+#undef strtoll
+
 #ifdef _MSC_VER
 #pragma warning(pop)
 #endif


### PR DESCRIPTION
<!-- Hi, thank you for taking the time to submit a pull request. -->
<!-- Please make sure that you fill this out in it's entirety. -->

### Description
Fixes some issues with standard C++ breaking due to OBS redefining reserved names as something else.
<!-- Describe your changes in as much detail as possible. -->
<!-- But please exclude your personal history from this. Only describe the changes -->

### Related Issues
<!-- - #0000 Name of Issue -->
<!-- - #0001 Name of Issue -->
