### PR TITLE
Add global configuration handler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -431,6 +431,8 @@ if(WIN32)
 endif()
 list(APPEND PROJECT_PRIVATE_SOURCE
 	# Plugin
+	"source/configuration.hpp"
+	"source/configuration.cpp"
 	"source/common.hpp"
 	"source/plugin.hpp"
 	"source/plugin.cpp"

--- a/source/configuration.cpp
+++ b/source/configuration.cpp
@@ -1,0 +1,102 @@
+/*
+ * Modern effects for a modern Streamer
+ * Copyright (C) 2020 Michael Fabian Dirks
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
+ */
+
+#include "configuration.hpp"
+#include "obs/obs-tools.hpp"
+#include "plugin.hpp"
+
+constexpr std::string_view version_tag_name = "Version";
+constexpr std::string_view path_backup_ext  = ".bk";
+
+streamfx::configuration::~configuration()
+{
+	// Update version tag.
+	obs_data_set_int(_data.get(), version_tag_name.data(), STREAMFX_VERSION);
+
+	try {
+		if (_config_path.has_parent_path()) {
+			std::filesystem::create_directories(_config_path.parent_path());
+		}
+		if (!obs_data_save_json_safe(_data.get(), _config_path.string().c_str(), ".tmp",
+									 _config_backup_path.string().c_str())) {
+			throw std::exception();
+		}
+	} catch (...) {
+		LOG_ERROR("Failed to save configuration, next start will be using defaults or backed up configuration.");
+	}
+}
+
+streamfx::configuration::configuration() : _data(), _config_path(), _config_backup_path()
+{
+	{ // Retrieve global configuration path.
+		const char* path    = obs_module_config_path("config.json");
+		_config_path        = path;
+		_config_backup_path = std::filesystem::path(_config_path).concat(path_backup_ext);
+	}
+
+	try {
+		if (!std::filesystem::exists(_config_path) || !std::filesystem::is_regular_file(_config_path)) {
+			throw std::exception();
+		} else {
+			obs_data_t* data = obs_data_create_from_json_file_safe(_config_path.string().c_str(),
+																   _config_backup_path.string().c_str());
+			if (!data) {
+				throw std::exception();
+			} else {
+				_data = std::shared_ptr<obs_data_t>(data, obs::obs_data_deleter);
+			}
+		}
+	} catch (...) {
+		_data = std::shared_ptr<obs_data_t>(obs_data_create(), obs::obs_data_deleter);
+	}
+}
+
+std::shared_ptr<obs_data_t> streamfx::configuration::get()
+{
+	obs_data_addref(_data.get());
+	return std::shared_ptr<obs_data_t>(_data.get(), obs::obs_data_deleter);
+}
+
+uint64_t streamfx::configuration::version()
+{
+	return static_cast<uint64_t>(obs_data_get_int(_data.get(), version_tag_name.data()));
+}
+
+bool streamfx::configuration::is_different_version()
+{
+	return (version() & STREAMFX_MASK_COMPAT) != (STREAMFX_VERSION & STREAMFX_MASK_COMPAT);
+}
+
+static std::shared_ptr<streamfx::configuration> _instance = nullptr;
+
+void streamfx::configuration::initialize()
+{
+	if (!_instance)
+		_instance = std::make_shared<streamfx::configuration>();
+}
+
+void streamfx::configuration::finalize()
+{
+	_instance.reset();
+}
+
+std::shared_ptr<streamfx::configuration> streamfx::configuration::instance()
+{
+	return _instance;
+}

--- a/source/configuration.hpp
+++ b/source/configuration.hpp
@@ -1,0 +1,48 @@
+/*
+ * Modern effects for a modern Streamer
+ * Copyright (C) 2020 Michael Fabian Dirks
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
+ */
+
+#pragma once
+#include "common.hpp"
+#include <filesystem>
+#include <memory>
+
+namespace streamfx {
+	class configuration {
+		std::shared_ptr<obs_data_t> _data;
+
+		std::filesystem::path _config_path;
+		std::filesystem::path _config_backup_path;
+
+		public:
+		~configuration();
+		configuration();
+
+		public:
+		std::shared_ptr<obs_data_t> get();
+
+		uint64_t version();
+
+		bool is_different_version();
+
+		public /* Singleton */:
+		static void                                     initialize();
+		static void                                     finalize();
+		static std::shared_ptr<streamfx::configuration> instance();
+	};
+} // namespace streamfx

--- a/source/obs/obs-tools.hpp
+++ b/source/obs/obs-tools.hpp
@@ -62,4 +62,9 @@ namespace obs {
 	{
 		obs_sceneitem_remove(v);
 	}
+
+	inline void obs_data_deleter(obs_data_t* v)
+	{
+		obs_data_release(v);
+	}
 } // namespace obs

--- a/source/plugin.cpp
+++ b/source/plugin.cpp
@@ -19,6 +19,7 @@
 
 #include "plugin.hpp"
 #include <stdexcept>
+#include "configuration.hpp"
 #include "obs/obs-source-tracker.hpp"
 
 #ifdef ENABLE_ENCODER_FFMPEG
@@ -68,6 +69,9 @@ try {
 	LOG_INFO("Loading Version %s", STREAMFX_VERSION_STRING);
 
 	global_threadpool = std::make_shared<util::threadpool>();
+
+	// Initialize Configuration
+	streamfx::configuration::initialize();
 
 	// Initialize Source Tracker
 	obs::source_tracker::initialize();
@@ -172,6 +176,9 @@ try {
 
 	// Finalize Source Tracker
 	obs::source_tracker::finalize();
+
+	// Finalize Configuration
+	streamfx::configuration::finalize();
 
 	global_threadpool.reset();
 } catch (...) {


### PR DESCRIPTION
<!-- Hi, thank you for taking the time to submit a pull request. -->
<!-- Please make sure that you fill this out in it's entirety. -->

### Description
Add a global configuration handler that stores per-user plugin configuration, which is not handled by OBS Studio. Things such as UI related settings should be stored in here instead of shoving it into other settings.

### Related Issues
<!-- - #0000 Name of Issue -->
<!-- - #0001 Name of Issue -->
