### PR TITLE
cmake: Place Windows exclusive functionality into own file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -492,6 +492,7 @@ if(WIN32)
 		"cmake/version.rc.in"
 	)
 	list(APPEND PROJECT_PRIVATE_SOURCE
+		"source/windll.cpp"
 	)	
 endif()
 

--- a/source/plugin.cpp
+++ b/source/plugin.cpp
@@ -178,18 +178,6 @@ try {
 	LOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
 }
 
-#ifdef _WIN32
-// Windows Only
-extern "C" {
-#include <Windows.h>
-}
-
-BOOL WINAPI DllMain(HINSTANCE, DWORD, LPVOID)
-{
-	return TRUE;
-}
-#endif
-
 std::shared_ptr<util::threadpool> get_global_threadpool()
 {
 	return global_threadpool;

--- a/source/windll.cpp
+++ b/source/windll.cpp
@@ -1,0 +1,25 @@
+/*
+ * Modern effects for a modern Streamer
+ * Copyright (C) 2020 Michael Fabian Dirks
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
+ */
+
+#include <Windows.h>
+
+BOOL WINAPI DllMain(HINSTANCE, DWORD, LPVOID)
+{
+	return TRUE;
+}


### PR DESCRIPTION
<!-- Hi, thank you for taking the time to submit a pull request. -->
<!-- Please make sure that you fill this out in it's entirety. -->

### Description
Moves Windows exclusive library functionality into it's own file, instead of polluting plugin.cpp.
<!-- Describe your changes in as much detail as possible. -->
<!-- But please exclude your personal history from this. Only describe the changes -->

### Related Issues
<!-- - #0000 Name of Issue -->
<!-- - #0001 Name of Issue -->
