### PR TITLE
project: Remove the usage of Visual Studio 2017

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,13 +7,8 @@ jobs:
     name: "Windows 64-bit"
     strategy:
       matrix: 
-        runner: [ windows-2016, windows-2019 ]
+        runner: [ windows-2019 ]
         include:
-          - runner: windows-2016
-            id: windows2017
-            windows_sdk: "10.0.17763.0"
-            cmake_generator: "Visual Studio 15 2017 Win64"
-            cmake_generator_platform: ""
           - runner: windows-2019
             id: windows2019
             windows_sdk: "10.0.18362.0"


### PR DESCRIPTION
<!-- Hi, thank you for taking the time to submit a pull request. -->
<!-- Please make sure that you fill this out in it's entirety. -->

### Description
Visual Studio 2017 is now 3 years out of date, and newer options are available - and also produce better and faster binaries.
<!-- Describe your changes in as much detail as possible. -->
<!-- But please exclude your personal history from this. Only describe the changes -->

### Related Issues
<!-- - #0000 Name of Issue -->
<!-- - #0001 Name of Issue -->
