### PR TITLE
cmake: Link to stdc++fs on GNU compatible and Clang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -495,7 +495,17 @@ if(WIN32)
 	)
 	list(APPEND PROJECT_PRIVATE_SOURCE
 		"source/windll.cpp"
-	)	
+	)
+endif()
+if((CMAKE_C_COMPILER_ID STREQUAL "GNU")
+	OR (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+	OR (CMAKE_C_COMPILER_ID STREQUAL "Clang")
+	OR (CMAKE_CXX_COMPILER_ID STREQUAL "Clang"))
+	if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 9.0)
+		list(APPEND PROJECT_LIBRARIES
+			"stdc++fs"
+		)
+	endif()
 endif()
 
 ## OBS Studio - Frontend/Qt


### PR DESCRIPTION
<!-- Hi, thank you for taking the time to submit a pull request. -->
<!-- Please make sure that you fill this out in it's entirety. -->

### Description
Fixes the issue with the lack of the linking to stdc++fs, which is required in order to get full C++17 on GNU GCC and Clang < 9.0. 
<!-- Describe your changes in as much detail as possible. -->
<!-- But please exclude your personal history from this. Only describe the changes -->

### Related Issues
<!-- - #0000 Name of Issue -->
<!-- - #0001 Name of Issue -->
