### PR TITLE
ci: Add Clang and ignore Crowdin branches

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,12 @@
 name: Build
 
-on: [push, pull_request]
+on:
+  push:
+    branches-ignore:
+      - 'l10n_master'
+  pull_request:
+    branches-ignore:
+      - 'l10n_master'
 
 jobs:
   windows:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,16 +57,36 @@ jobs:
     strategy:
       matrix: 
         runner: [ ubuntu-18.04, ubuntu-latest ]
+        compiler: [ gcc, clang ]
         include:
           - runner: ubuntu-18.04
-            gcc: 8
-            id: ubuntu1804
+            compiler: gcc
+            compiler-cxx: g++
+            compiler-version: 8
+            packages: gcc-8 g++8
+            extra_command: sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 800 --slave /usr/bin/g++ g++ /usr/bin/g++-8
+            id: ubuntu1804-gcc8
           - runner: ubuntu-latest
-            gcc: 9
-            id: ubuntu1910
+            compiler: gcc
+            compiler-cxx: g++
+            compiler-version: 9
+            extra_command: sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 800 --slave /usr/bin/g++ g++ /usr/bin/g++-9
+            id: ubuntu1910-gcc9
+          - runner: ubuntu-latest
+            compiler: clang
+            compiler-cxx: clang++
+            compiler-version: 9
+            packages: clang-9
+            extra_command: ""
+            id: ubuntu1910-clang9
+        exclude:
+          - runner: ubuntu-18.04
+            compiler: clang
     runs-on: ${{ matrix.runner }}
     env:
       CMAKE_GENERATOR: "Ninja"
+      CC: ${{ matrix.compiler }}
+      CXX: ${{ matrix.compiler-cxx }}
     steps:
     - name: "Clone Repository"
       uses: actions/checkout@v1
@@ -79,8 +99,7 @@ jobs:
         sudo apt-get -qq update
         sudo apt-get install \
           build-essential \
-          gcc-${{ matrix.gcc }} \
-          g++-${{ matrix.gcc }} \
+          ${{ matrix.packages }} \
           checkinstall \
           cmake \
           ninja-build \
@@ -97,7 +116,7 @@ jobs:
           libqt5svg5-dev \
           libgl1-mesa-dev \
           pkg-config
-        sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${{ matrix.gcc }} 800 --slave /usr/bin/g++ g++ /usr/bin/g++-${{ matrix.gcc }}
+        ${{ matrix.extra_command }}
     - name: "Configure Project"
       shell: bash
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,6 +32,36 @@ jobs:
     - name: "Clone Submodules"
       shell: bash
       run: git submodule update --init --recursive
+    - name: "Cache: OBS"
+      uses: actions/cache@v1
+      env:
+        cache-name: cache-libobs
+      with:
+        path: build/temp/libobs-src
+        key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('CMakeLists.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-${{ env.cache-name }}-
+          ${{ runner.os }}-${{ env.cache-name }}
+    - name: "Cache: OBS Dependencies"
+      uses: actions/cache@v1
+      env:
+        cache-name: cache-libobs-deps
+      with:
+        path: build/temp/obsdeps-src
+        key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('CMakeLists.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-${{ env.cache-name }}-
+          ${{ runner.os }}-${{ env.cache-name }}
+    - name: "Cache: Qt"
+      uses: actions/cache@v1
+      env:
+        cache-name: cache-qt
+      with:
+        path: build/temp/qt-src
+        key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('CMakeLists.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-${{ env.cache-name }}-
+          ${{ runner.os }}-${{ env.cache-name }}
     - name: "Configure Project"
       shell: bash
       run: |
@@ -123,6 +153,16 @@ jobs:
           libgl1-mesa-dev \
           pkg-config
         ${{ matrix.extra_command }}
+    - name: "Cache: OBS"
+      uses: actions/cache@v1
+      env:
+        cache-name: cache-libobs
+      with:
+        path: build/temp/libobs-src
+        key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('CMakeLists.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-${{ env.cache-name }}-
+          ${{ runner.os }}-${{ env.cache-name }}
     - name: "Configure Project"
       shell: bash
       run: |

--- a/source/util-event.hpp
+++ b/source/util-event.hpp
@@ -151,7 +151,7 @@ namespace util {
 				_cb_clear();
 			}
 		}
-		inline event<_args...>& operator=(nullptr_t)
+		inline event<_args...>& operator=(std::nullptr_t)
 		{
 			clear();
 			return *this;

--- a/source/util-profiler.cpp
+++ b/source/util-profiler.cpp
@@ -167,5 +167,5 @@ void util::profiler::instance::cancel()
 
 void util::profiler::instance::reparent(std::shared_ptr<util::profiler> parent)
 {
-	parent = parent;
+	_parent = parent;
 }


### PR DESCRIPTION
<!-- Hi, thank you for taking the time to submit a pull request. -->
<!-- Please make sure that you fill this out in it's entirety. -->

### Description
Adds Clang-9 to the supported compilers which is a more optimized compiler than GCC and cross-platform as well. Additionally adds caching of dependencies in order to reduce build times.
<!-- Describe your changes in as much detail as possible. -->
<!-- But please exclude your personal history from this. Only describe the changes -->

### Related Issues
- #146 Clang issues
<!-- - #0000 Name of Issue -->
<!-- - #0001 Name of Issue -->
