### PR TITLE
ui: Fix incorrect namespace for Qt symbol

### DIFF
--- a/source/ui/ui.cpp
+++ b/source/ui/ui.cpp
@@ -47,6 +47,16 @@ constexpr std::string_view _url_website      = "https://streamfx.xaymar.com";
 constexpr std::string_view _url_discord      = "https://discordapp.com/invite/DaeJg7M";
 constexpr std::string_view _url_github       = "https://github.com/Xaymar/obs-StreamFX";
 
+inline void qt_init_resource()
+{
+	Q_INIT_RESOURCE(streamfx);
+}
+
+inline void qt_cleanup_resource()
+{
+	Q_CLEANUP_RESOURCE(streamfx);
+}
+
 bool streamfx::ui::handler::have_shown_about_streamfx(bool shown)
 {
 	if (shown) {
@@ -69,7 +79,7 @@ streamfx::ui::handler::handler()
 	  _about_action(), _about_dialog()
 {
 	// Qt Resources and Translators
-	Q_INIT_RESOURCE(streamfx);
+	qt_init_resource();
 	QCoreApplication::installTranslator(new streamfx::ui::translator(this));
 
 	// Handle all frontend events.
@@ -116,7 +126,7 @@ streamfx::ui::handler::~handler()
 	obs_frontend_remove_event_callback(frontend_event_handler, this);
 
 	// Qt Resources and Translators
-	Q_CLEANUP_RESOURCE(streamfx);
+	qt_cleanup_resource();
 }
 
 void streamfx::ui::handler::frontend_event_handler(obs_frontend_event event, void* private_data)


### PR DESCRIPTION
<!-- Hi, thank you for taking the time to submit a pull request. -->
<!-- Please make sure that you fill this out in it's entirety. -->

### Description
Q_INIT_RESOURCE and Q_CLEANUP_RESOURCE can't be called from within a namespace and instead have to be in outside of the namespace, so by moving them into small inline functions we can fulfill this restriction.
<!-- Describe your changes in as much detail as possible. -->
<!-- But please exclude your personal history from this. Only describe the changes -->

### Related Issues
- #192 Missing Qt symbol on Arch Linux
- #155 Binaries not working on various distros
