### PR TITLE
gs-mipmapper: ~2000% performance improvement and removal of unimplemented functionality

### DIFF
--- a/data/effects/mipgen.effect
+++ b/data/effects/mipgen.effect
@@ -1,172 +1,35 @@
 uniform float4x4 ViewProj;
 uniform texture2d image;
-uniform int level;
 uniform float2 imageTexel;
-uniform float strength;
+uniform int level;
 
-sampler_state pointSampler {
-	Filter    = Point;
-	AddressU  = Clamp;
-	AddressV  = Clamp;
-};
-
-sampler_state linearSampler {
+sampler_state def_sampler {
 	Filter    = Linear;
 	AddressU  = Clamp;
 	AddressV  = Clamp;
 };
 
-struct VertDataIn {
+struct VertexData {
 	float4 pos : POSITION;
 	float2 uv  : TEXCOORD0;
 };
 
-struct VertDataOut {
-	float4 pos : POSITION;
-	float2 uv  : TEXCOORD0;
-};
-
-VertDataOut VSDefault(VertDataIn v_in)
+VertexData VSDefault(VertexData vtx)
 {
-	VertDataOut vert_out;
-	vert_out.pos = mul(float4(v_in.pos.xyz, 1.0), ViewProj);
-	vert_out.uv  = v_in.uv;
-	return vert_out;
+	vtx.pos = mul(float4(vtx.pos.xyz, 1.0), ViewProj);
+	return vtx;
 }
 
-float4 PSPoint(VertDataOut v_in) : TARGET
+float4 PSDefault(VertexData vtx) : TARGET
 {
-	return image.SampleLevel(pointSampler, v_in.uv, level);
+	return image.SampleLevel(def_sampler, vtx.uv, level);
 }
 
-float4 PSLinear(VertDataOut v_in) : TARGET
-{
-	return image.SampleLevel(linearSampler, v_in.uv, level);
-}
-
-float4 PSSharpen(VertDataOut v_in) : TARGET
-{
-	float2 ul, ur, dl, dr, u, d, l, r;
-	ul = float2(-imageTexel.x, -imageTexel.y);
-	ur = float2(imageTexel.x, -imageTexel.y);
-	dl = -ur;
-	dr = -ul;
-	u = float2(0, -imageTexel.y);
-	d = -u;
-	l = float2(-imageTexel.x, 0);
-	r = -l;
-	
-	float4 tl, tc, tr, cl, cc, cr, bl, bc, br;
-	tl = image.SampleLevel(pointSampler, v_in.uv + ul, level);
-	tc = image.SampleLevel(pointSampler, v_in.uv + u, level);
-	tr = image.SampleLevel(pointSampler, v_in.uv + ur, level);
-	cl = image.SampleLevel(pointSampler, v_in.uv + l, level);
-	cc = image.SampleLevel(pointSampler, v_in.uv, level);
-	cr = image.SampleLevel(pointSampler, v_in.uv + r, level);
-	bl = image.SampleLevel(pointSampler, v_in.uv + dl, level);
-	bc = image.SampleLevel(pointSampler, v_in.uv + d, level);
-	br = image.SampleLevel(pointSampler, v_in.uv + dr, level);
-
-	float kernel1, kernel2, kernel3;
-	kernel1 = -0.25 * strength;
-	kernel2 = -0.50 * strength;
-	kernel3 = abs(kernel1 * 4) + abs(kernel2 * 4) + 1;
-
-	return (tl * kernel1) + (tr * kernel1) + (bl * kernel1) + (br * kernel1) + (cl * kernel2) + (cr * kernel2) + (tc * kernel2) + (bc * kernel2) + (cc * kernel3);
-}
-
-float4 PSSmoothen(VertDataOut v_in) : TARGET
-{
-	// If we use linear sampling, we can get away with just 4 total sampler queries.
-	// However this is not a cheap implementation, it's just meant to be accurate so we do each sampler query and rely on the compiler.
-
-	float3 smoothKernel3 = float3(0.0574428, 0.0947072, 0.3914000);
-	float2 ul, ur, dl, dr, u, d, l, r;
-	float4 tl, tc, tr, cl, cc, cr, bl, bc, br;
-	float limitstr = clamp(strength, 0.0, 1.0);
-
-	ul = float2(-imageTexel.x, -imageTexel.y);
-	ur = float2(imageTexel.x, -imageTexel.y);
-	dl = -ur;
-	dr = -ul;
-	u = float2(0, -imageTexel.y);
-	d = -u;
-	l = float2(-imageTexel.x, 0);
-	r = -l;
-	
-	tl = image.SampleLevel(pointSampler, v_in.uv + ul * limitstr, level) * smoothKernel3[0];
-	tc = image.SampleLevel(pointSampler, v_in.uv + u * limitstr, level) * smoothKernel3[1];
-	tr = image.SampleLevel(pointSampler, v_in.uv + ur * limitstr, level) * smoothKernel3[0];
-	cl = image.SampleLevel(pointSampler, v_in.uv + l * limitstr, level) * smoothKernel3[1];
-	cc = image.SampleLevel(pointSampler, v_in.uv, level) * smoothKernel3[2];
-	cr = image.SampleLevel(pointSampler, v_in.uv + r * limitstr, level) * smoothKernel3[1];
-	bl = image.SampleLevel(pointSampler, v_in.uv + dl * limitstr, level) * smoothKernel3[0];
-	bc = image.SampleLevel(pointSampler, v_in.uv + d * limitstr, level) * smoothKernel3[1];
-	br = image.SampleLevel(pointSampler, v_in.uv + dr * limitstr, level) * smoothKernel3[0];
-
-	return tl + tc + tr + cl + cc + cr + bl + bc + br;
-}
-
-float4 PSBicubic(VertDataOut v_in) : TARGET
-{
-	return float4(1.0, 0.0, 1.0, 1.0);
-}
-
-float4 PSLanczos(VertDataOut v_in) : TARGET
-{
-	return float4(1.0, 0.0, 1.0, 1.0);
-}
-
-technique Point
+technique Draw
 {
 	pass
 	{
-		vertex_shader = VSDefault(v_in);
-		pixel_shader  = PSPoint(v_in);
-	}
-}
-
-technique Linear
-{
-	pass
-	{
-		vertex_shader = VSDefault(v_in);
-		pixel_shader  = PSLinear(v_in);
-	}
-}
-
-technique Sharpen
-{
-	pass
-	{
-		vertex_shader = VSDefault(v_in);
-		pixel_shader  = PSSharpen(v_in);
-	}
-}
-
-technique Smoothen
-{
-	pass
-	{
-		vertex_shader = VSDefault(v_in);
-		pixel_shader  = PSSmoothen(v_in);
-	}
-}
-
-technique Bicubic
-{
-	pass
-	{
-		vertex_shader = VSDefault(v_in);
-		pixel_shader  = PSBicubic(v_in);
-	}
-}
-
-technique Lanczos
-{
-	pass
-	{
-		vertex_shader = VSDefault(v_in);
-		pixel_shader  = PSLanczos(v_in);
+		vertex_shader = VSDefault(vtx);
+		pixel_shader  = PSDefault(vtx);
 	}
 }

--- a/source/filters/filter-transform.hpp
+++ b/source/filters/filter-transform.hpp
@@ -36,8 +36,6 @@ namespace streamfx::filter::transform {
 		// Mip-mapping
 		bool                         _mipmap_enabled;
 		bool                         _mipmap_rendered;
-		double_t                     _mipmap_strength;
-		gs::mipmapper::generator     _mipmap_generator;
 		gs::mipmapper                _mipmapper;
 		std::shared_ptr<gs::texture> _mipmap_texture;
 

--- a/source/obs/gs/gs-mipmapper.cpp
+++ b/source/obs/gs/gs-mipmapper.cpp
@@ -22,46 +22,18 @@
 #include "obs/gs/gs-helper.hpp"
 #include "plugin.hpp"
 
-#if defined(WIN32) || defined(WIN64)
+#ifdef _WIN32
 #ifdef _MSC_VER
 #pragma warning(push)
-#pragma warning(disable : 5039)
+#pragma warning(disable : 4201 4365 5039)
 #endif
 #include <Windows.h>
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif
-#endif
-
-// Here be dragons!
-// This is to add support for mipmap generation which is by default not possible with libobs.
-// OBS hides a ton of possible things from us, which we'd have to simulate - or just hack around.
-struct graphics_subsystem {
-	void*        module;
-	gs_device_t* device;
-	// No other fields required.
-};
-
-#if defined(WIN32) || defined(WIN64)
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable : 4201 4365)
-#endif
+#include <atlutil.h>
 #include <d3d11.h>
 #include <dxgi.h>
-#include <util/windows/ComPtr.hpp>
 #ifdef _MSC_VER
 #pragma warning(pop)
 #endif
-
-// Slaughtered copy of d3d11-subsystem.hpp gs_device. We only need up to device and context, the rest is "unknown" to us.
-struct gs_d3d11_device {
-	ComPtr<IDXGIFactory1>       factory;
-	ComPtr<IDXGIAdapter1>       adapter;
-	ComPtr<ID3D11Device>        device;
-	ComPtr<ID3D11DeviceContext> context;
-	// No other fields required.
-};
 #endif
 
 gs::mipmapper::~mipmapper()
@@ -73,200 +45,182 @@ gs::mipmapper::~mipmapper()
 
 gs::mipmapper::mipmapper()
 {
-	_vb            = std::make_unique<gs::vertex_buffer>(uint32_t(6u), std::uint8_t(1u));
-	auto v0        = _vb->at(0);
-	v0.position->x = 0;
-	v0.position->y = 0;
-	v0.uv[0]->x    = 0;
-	v0.uv[0]->y    = 0;
+	_vb = std::make_unique<gs::vertex_buffer>(uint32_t(3u), std::uint8_t(1u));
 
-	auto v1        = _vb->at(1);
-	auto v4        = _vb->at(4);
-	v4.position->x = v1.position->x = 1.0;
-	v4.position->y = v1.position->y = 0;
-	v4.uv[0]->x = v1.uv[0]->x = 1.0;
-	v4.uv[0]->y = v1.uv[0]->y = 0;
-
-	auto v2        = _vb->at(2);
-	auto v3        = _vb->at(3);
-	v3.position->x = v2.position->x = 0;
-	v3.position->y = v2.position->y = 1.0;
-	v3.uv[0]->x = v2.uv[0]->x = 0;
-	v3.uv[0]->y = v2.uv[0]->y = 1.0;
-
-	auto v5        = _vb->at(5);
-	v5.position->x = 1.0;
-	v5.position->y = 1.0;
-	v5.uv[0]->x    = 1.0;
-	v5.uv[0]->y    = 1.0;
+	{
+		auto vtx        = _vb->at(0);
+		vtx.position->x = 0;
+		vtx.position->y = 0;
+		vtx.uv[0]->x    = 0;
+		vtx.uv[0]->y    = 0;
+	}
+	{
+		auto vtx        = _vb->at(1);
+		vtx.position->x = 0.;
+		vtx.position->y = 2.;
+		vtx.uv[0]->x    = 0.;
+		vtx.uv[0]->y    = 2.;
+	}
+	{
+		auto vtx        = _vb->at(2);
+		vtx.position->x = 2.;
+		vtx.position->y = 0.;
+		vtx.uv[0]->x    = 2.;
+		vtx.uv[0]->y    = 0.;
+	}
 
 	_vb->update();
 
-	char* effect_file = obs_module_file("effects/mipgen.effect");
-	_effect           = gs::effect::create(effect_file);
-	bfree(effect_file);
+	{
+		char* path = obs_module_file("effects/mipgen.effect");
+		_effect    = gs::effect::create(path);
+		bfree(path);
+	}
 }
 
-void gs::mipmapper::rebuild(std::shared_ptr<gs::texture> source, std::shared_ptr<gs::texture> target,
-							gs::mipmapper::generator generator = gs::mipmapper::generator::Linear,
-							float_t                  strength  = 1.0)
+void gs::mipmapper::rebuild(std::shared_ptr<gs::texture> source, std::shared_ptr<gs::texture> target)
 {
-	// Here be dragons! You have been warned.
+	{ // Validate arguments and structure.
+		if (!source || !target)
+			return; // Do nothing if source or target are missing.
 
-	// Do nothing if there is no texture given.
-	if (!source) {
-#ifdef _DEBUG
-		assert(!source);
-#endif
-		return;
-	}
-	if (!target) {
-#ifdef _DEBUG
-		assert(!target);
-#endif
-		return;
-	}
+		if (!_vb || !_effect)
+			return; // Do nothing if the necessary data failed to load.
 
-	// Ensure texture sizes match
-	if ((source->get_width() != target->get_width()) || (source->get_height() != target->get_height())) {
-		throw std::invalid_argument("source and target must have same size");
-	}
+		// Ensure texture sizes match
+		if ((source->get_width() != target->get_width()) || (source->get_height() != target->get_height())) {
+			throw std::invalid_argument("source and target must have same size");
+		}
 
-	// Ensure texture types match
-	if ((source->get_type() != target->get_type())) {
-		throw std::invalid_argument("source and target must have same type");
+		// Ensure texture types match
+		if ((source->get_type() != target->get_type())) {
+			throw std::invalid_argument("source and target must have same type");
+		}
+
+		// Ensure texture formats match
+		if ((source->get_color_format() != target->get_color_format())) {
+			throw std::invalid_argument("source and target must have same format");
+		}
 	}
 
-	// Ensure texture formats match
-	if ((source->get_color_format() != target->get_color_format())) {
-		throw std::invalid_argument("source and target must have same format");
-	}
-
+	// Get a unique lock on the graphics context.
 	auto gctx = gs::context();
 
-	// Copy original texture
-	//gs_copy_texture(target->get_object(), source->get_object());
-
-	// Test if we actually need to recreate the render target for a different format or at all.
+	// Do we need to recreate the render target for a different format?
 	if ((!_rt) || (source->get_color_format() != _rt->get_color_format())) {
 		_rt = std::make_unique<gs::rendertarget>(source->get_color_format(), GS_ZS_NONE);
 	}
 
-	// Render
-#if defined(WIN32) || defined(WIN64)
-	graphics_t*      ctx = gs_get_context();
-	gs_d3d11_device* dev = reinterpret_cast<gs_d3d11_device*>(ctx->device);
+	// Grab API related information.
+#ifdef _WIN32
+	ID3D11Device*        d3d_device  = nullptr;
+	ID3D11DeviceContext* d3d_context = nullptr;
+	ID3D11Resource*      d3d_source  = nullptr;
+	ID3D11Resource*      d3d_target  = nullptr;
+	if (gs_get_device_type() == GS_DEVICE_DIRECT3D_11) {
+		D3D11_TEXTURE2D_DESC td;
+		d3d_source = reinterpret_cast<ID3D11Resource*>(gs_texture_get_obj(source->get_object()));
+		d3d_target = reinterpret_cast<ID3D11Resource*>(gs_texture_get_obj(target->get_object()));
+		d3d_device = reinterpret_cast<ID3D11Device*>(gs_get_device_obj());
+		d3d_device->GetImmediateContext(&d3d_context);
+	}
 #endif
-	int         device_type = gs_get_device_type();
-	std::string technique   = "Draw";
-
-	switch (generator) {
-	case generator::Point:
-		technique = "Point";
-		break;
-	case generator::Linear:
-		technique = "Linear";
-		break;
-	case generator::Sharpen:
-		technique = "Sharpen";
-		break;
-	case generator::Smoothen:
-		technique = "Smoothen";
-		break;
-	case generator::Bicubic:
-		technique = "Bicubic";
-		break;
-	case generator::Lanczos:
-		technique = "Lanczos";
-		break;
+	if (gs_get_device_type() == GS_DEVICE_OPENGL) {
+		// FixMe! Implement OpenGL
 	}
 
-	gs_load_vertexbuffer(_vb->update());
-	gs_load_indexbuffer(nullptr);
-
+	// Use different methods for different types of textures.
 	if (source->get_type() == gs::texture::type::Normal) {
-		std::size_t texture_width  = source->get_width();
-		std::size_t texture_height = source->get_height();
-		float_t     texel_width    = 1.0f / texture_width;
-		float_t     texel_height   = 1.0f / texture_height;
-		std::size_t mip_levels     = 1;
+		while (true) {
+			uint32_t width         = source->get_width();
+			uint32_t height        = source->get_height();
+			size_t   max_mip_level = 1;
 
-#if defined(WIN32) || defined(WIN64)
-		ID3D11Texture2D* target_t2 = nullptr;
-		ID3D11Texture2D* source_t2 = nullptr;
-		if (device_type == GS_DEVICE_DIRECT3D_11) {
-			// We definitely have a Direct3D11 resource.
-			D3D11_TEXTURE2D_DESC target_t2desc;
-			target_t2 = reinterpret_cast<ID3D11Texture2D*>(gs_texture_get_obj(target->get_object()));
-			source_t2 = reinterpret_cast<ID3D11Texture2D*>(gs_texture_get_obj(source->get_object()));
-			target_t2->GetDesc(&target_t2desc);
-			dev->context->CopySubresourceRegion(target_t2, 0, 0, 0, 0, source_t2, 0, nullptr);
-			mip_levels = target_t2desc.MipLevels;
-		}
+			{
+				auto cctr = gs::debug_marker(gs::debug_color_azure_radiance, "Mip Level %lld", 0);
+#ifdef _WIN32
+				if (gs_get_device_type() == GS_DEVICE_DIRECT3D_11) {
+					{ // Retrieve maximum mip map level.
+						D3D11_TEXTURE2D_DESC td;
+						reinterpret_cast<ID3D11Texture2D*>(d3d_target)->GetDesc(&td);
+						max_mip_level = td.MipLevels;
+					}
+
+					// Copy mip level 0 across textures.
+					d3d_context->CopySubresourceRegion(d3d_target, 0, 0, 0, 0, d3d_source, 0, nullptr);
+				}
 #endif
-		if (device_type == GS_DEVICE_OPENGL) {
-			// This is an OpenGL resource.
-		}
-
-		// If we do not have any miplevels, just stop now.
-		if (mip_levels == 1) {
-			return;
-		}
-
-		for (std::size_t mip = 1; mip < mip_levels; mip++) {
-			texture_width /= 2;
-			texture_height /= 2;
-			if (texture_width == 0) {
-				texture_width = 1;
-			}
-			if (texture_height == 0) {
-				texture_height = 1;
+				if (gs_get_device_type() == GS_DEVICE_OPENGL) {
+					// FixMe! Implement OpenGL
+				}
 			}
 
-			texel_width  = 1.0f / texture_width;
-			texel_height = 1.0f / texture_height;
+			// Do we even need to do anything here?
+			if (max_mip_level == 1)
+				break;
 
-			// Draw mipmap layer
-			try {
-				auto op = _rt->render(uint32_t(texture_width), uint32_t(texture_height));
+			// Render each mip map level.
+			for (size_t mip = 1; mip < max_mip_level; mip++) {
+				auto cctr = gs::debug_marker(gs::debug_color_azure_radiance, "Mip Level %lld", mip);
 
-				gs_set_cull_mode(GS_NEITHER);
+				uint32_t cwidth  = std::max<uint32_t>(width >> mip, 1);
+				uint32_t cheight = std::max<uint32_t>(height >> mip, 1);
+				float_t  iwidth  = 1. / static_cast<float_t>(cwidth);
+				float_t  iheight = 1. / static_cast<float_t>(cheight);
+
+				// Set up rendering state.
+				gs_load_vertexbuffer(_vb->update(false));
+				gs_load_indexbuffer(nullptr);
+				gs_blend_state_push();
 				gs_reset_blend_state();
-				gs_blend_function_separate(gs_blend_type::GS_BLEND_ONE, gs_blend_type::GS_BLEND_ZERO,
-										   gs_blend_type::GS_BLEND_ONE, gs_blend_type::GS_BLEND_ZERO);
+				gs_enable_blending(false);
+				gs_blend_function(GS_BLEND_ONE, GS_BLEND_ZERO);
+				gs_enable_color(true, true, true, true);
 				gs_enable_depth_test(false);
 				gs_enable_stencil_test(false);
 				gs_enable_stencil_write(false);
-				gs_enable_color(true, true, true, true);
-				gs_ortho(0, 1, 0, 1, -1, 1);
+				gs_set_cull_mode(GS_NEITHER);
+				try {
+					auto op = _rt->render(width, height);
+					gs_set_viewport(0, 0, cwidth, cheight);
+					gs_ortho(0, 1, 0, 1, 0, 1);
 
-				vec4 black;
-				vec4_zero(&black);
-				gs_clear(GS_CLEAR_COLOR | GS_CLEAR_DEPTH, &black, 0, 0);
+					vec4 black = {1., 1., 1., 1};
+					gs_clear(GS_CLEAR_COLOR | GS_CLEAR_DEPTH, &black, 0, 0);
 
-				_effect.get_parameter("image").set_texture(target);
-				_effect.get_parameter("level").set_int(int32_t(mip - 1));
-				_effect.get_parameter("imageTexel").set_float2(texel_width, texel_height);
-				_effect.get_parameter("strength").set_float(strength);
-
-				while (gs_effect_loop(_effect.get_object(), technique.c_str())) {
-					gs_draw(gs_draw_mode::GS_TRIS, 0, _vb->size());
+					_effect.get_parameter("image").set_texture(target);
+					_effect.get_parameter("imageTexel").set_float2(iwidth, iheight);
+					_effect.get_parameter("level").set_int(int32_t(mip - 1));
+					while (gs_effect_loop(_effect.get_object(), "Draw")) {
+						gs_draw(gs_draw_mode::GS_TRIS, 0, _vb->size());
+					}
+				} catch (...) {
 				}
-			} catch (...) {
-				LOG_ERROR("Failed to render mipmap layer.");
-			}
 
-#if defined(WIN32) || defined(WIN64)
-			if (device_type == GS_DEVICE_DIRECT3D_11) {
-				// Copy
-				ID3D11Texture2D* rt    = reinterpret_cast<ID3D11Texture2D*>(gs_texture_get_obj(_rt->get_object()));
-				std::uint32_t    level = uint32_t(D3D11CalcSubresource(UINT(mip), 0, UINT(mip_levels)));
-				dev->context->CopySubresourceRegion(target_t2, level, 0, 0, 0, rt, 0, NULL);
-			}
+				// Clean up rendering state.
+				gs_load_indexbuffer(nullptr);
+				gs_load_vertexbuffer(nullptr);
+				gs_blend_state_pop();
+
+				// Copy from the render target to the target mip level.
+#ifdef _WIN32
+				if (gs_get_device_type() == GS_DEVICE_DIRECT3D_11) {
+					ID3D11Texture2D* rtt =
+						reinterpret_cast<ID3D11Texture2D*>(gs_texture_get_obj(_rt->get_texture()->get_object()));
+					std::uint32_t level = uint32_t(D3D11CalcSubresource(UINT(mip), 0, UINT(max_mip_level)));
+
+					D3D11_BOX box = {0, 0, 0, cwidth, cheight, 1};
+					d3d_context->CopySubresourceRegion(d3d_target, level, 0, 0, 0, rtt, 0, &box);
+				}
 #endif
-		}
-	}
+				if (gs_get_device_type() == GS_DEVICE_OPENGL) {
+					// FixMe! Implement OpenGL
+				}
+			}
 
-	gs_load_indexbuffer(nullptr);
-	gs_load_vertexbuffer(nullptr);
+			break;
+		}
+	} else {
+		throw std::runtime_error("Texture type is not supported by mipmapping yet.");
+	}
 }

--- a/source/obs/gs/gs-mipmapper.hpp
+++ b/source/obs/gs/gs-mipmapper.hpp
@@ -24,6 +24,18 @@
 #include "gs-texture.hpp"
 #include "gs-vertexbuffer.hpp"
 
+/* gs::mipmapper is an attempt at adding dynamic mip-map generation to a software
+ *  which only supports static mip-maps. It is effectively an incredibly bad hack
+ *  instead of a proper solution - can break any time and likely already has.
+ *
+ * Needless to say, dynamic mip-map generation costs a lot of GPU time, especially
+ *  when things need to be synchronized. In the ideal case we would just render 
+ *  straight to the mip level, but this is not possible in DirectX 11 and OpenGL.
+ * 
+ * So instead we render to a render target and copy from there to the actual
+ *  resource. Super wasteful, but what else can we actually do?
+ */
+
 namespace gs {
 	class mipmapper {
 		std::unique_ptr<gs::vertex_buffer> _vb;
@@ -31,20 +43,9 @@ namespace gs {
 		gs::effect                         _effect;
 
 		public:
-		enum class generator : std::uint8_t {
-			Point,
-			Linear,
-			Sharpen,
-			Smoothen,
-			Bicubic,
-			Lanczos,
-		};
-
-		public:
 		~mipmapper();
 		mipmapper();
 
-		void rebuild(std::shared_ptr<gs::texture> source, std::shared_ptr<gs::texture> target,
-					 gs::mipmapper::generator generator, float_t strength);
+		void rebuild(std::shared_ptr<gs::texture> source, std::shared_ptr<gs::texture> target);
 	};
 } // namespace gs

--- a/source/obs/gs/gs-vertexbuffer.cpp
+++ b/source/obs/gs/gs-vertexbuffer.cpp
@@ -36,9 +36,13 @@ void gs::vertex_buffer::initialize(std::size_t capacity, std::size_t layers)
 	_data->num     = _capacity;
 	_data->num_tex = _layers;
 	_data->points = _positions = (vec3*)util::malloc_aligned(16, sizeof(vec3) * _capacity);
+	memset(_positions, 0, sizeof(vec3) * _capacity);
 	_data->normals = _normals = (vec3*)util::malloc_aligned(16, sizeof(vec3) * _capacity);
+	memset(_normals, 0, sizeof(vec3) * _capacity);
 	_data->tangents = _tangents = (vec3*)util::malloc_aligned(16, sizeof(vec3) * _capacity);
+	memset(_tangents, 0, sizeof(vec3) * _capacity);
 	_data->colors = _colors = (uint32_t*)util::malloc_aligned(16, sizeof(uint32_t) * _capacity);
+	memset(_colors, 0, sizeof(uint32_t) * _capacity);
 	if (_layers > 0) {
 		_data->tvarray = _layer_data = (gs_tvertarray*)util::malloc_aligned(16, sizeof(gs_tvertarray) * _layers);
 		for (std::size_t n = 0; n < _layers; n++) {
@@ -112,7 +116,7 @@ gs::vertex_buffer::vertex_buffer(std::uint32_t vertices, std::uint8_t uvlayers)
 
 	// Allocate GPU
 	auto gctx = gs::context();
-	_buffer   = gs_vertexbuffer_create(_data, GS_DYNAMIC);
+	_buffer   = gs_vertexbuffer_create(_data, GS_DYNAMIC | GS_DUP_BUFFER);
 	memset(_data, 0, sizeof(gs_vb_data));
 	_data->num     = _capacity;
 	_data->num_tex = _layers;

--- a/source/strings.hpp
+++ b/source/strings.hpp
@@ -72,15 +72,6 @@
 #define S_BLUR_SUBTYPE_ROTATIONAL "Blur.Subtype.Rotational"
 #define S_BLUR_SUBTYPE_ZOOM "Blur.Subtype.Zoom"
 
-#define S_MIPGENERATOR "MipGenerator"
-#define S_MIPGENERATOR_POINT "MipGenerator.Point"
-#define S_MIPGENERATOR_LINEAR "MipGenerator.Linear"
-#define S_MIPGENERATOR_SHARPEN "MipGenerator.Sharpen"
-#define S_MIPGENERATOR_SMOOTHEN "MipGenerator.Smoothen"
-#define S_MIPGENERATOR_BICUBIC "MipGenerator.Bicubic"
-#define S_MIPGENERATOR_LANCZOS "MipGenerator.Lanczos"
-#define S_MIPGENERATOR_INTENSITY "MipGenerator.Intensity"
-
 #define S_CHANNEL_RED "Channel.Red"
 #define S_CHANNEL_GREEN "Channel.Green"
 #define S_CHANNEL_BLUE "Channel.Blue"


### PR DESCRIPTION
<!-- Hi, thank you for taking the time to submit a pull request. -->
<!-- Please make sure that you fill this out in it's entirety. -->

### Description
The new libOBS API allows us to directly access the underlying API instead of having to mess around in memory. By using it we can avoid crashing in case the compiler for it is different, or in case the actual back end structure changes.

Additionally the mostly unimplemented and unused options have also been removed, which streamlines the use of this class even further and reduces both shader and code complexity.

Finally by optimizing the use of the internal render target we can achieve a speed up of up to 3000% over the old way, allowing for many more mipmapped filters.
<!-- Describe your changes in as much detail as possible. -->
<!-- But please exclude your personal history from this. Only describe the changes -->

### Related Issues
- #129 Linux/Mac have no mipmapping support
- #166 Weird artifacts when using mipmapping in 3D Transform on Browser sources.
<!-- - #0000 Name of Issue -->
<!-- - #0001 Name of Issue -->
