### PR TITLE
project: Improve performance profiling support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -230,7 +230,9 @@ else()
 	set(ENABLE_SOURCE_SHADER TRUE)
 	set(ENABLE_TRANSITION_SHADER TRUE)
 endif()
+## Encoders
 set(${PropertyPrefix}ENABLE_ENCODER_FFMPEG ${ENABLE_ENCODER_FFMPEG} CACHE BOOL "Enable FFmpeg Encoder")
+## Filters
 set(${PropertyPrefix}ENABLE_FILTER_BLUR ${ENABLE_FILTER_BLUR} CACHE BOOL "Enable Blur Filter")
 set(${PropertyPrefix}ENABLE_FILTER_COLOR_GRADE ${ENABLE_FILTER_COLOR_GRADE} CACHE BOOL "Enable Color Grade Filter")
 set(${PropertyPrefix}ENABLE_FILTER_DISPLACEMENT ${ENABLE_FILTER_DISPLACEMENT} CACHE BOOL "Enable Displacement Filter")
@@ -239,9 +241,13 @@ set(${PropertyPrefix}ENABLE_FILTER_NVIDIA_FACE_TRACKING ${ENABLE_FILTER_NVIDIA_F
 set(${PropertyPrefix}ENABLE_FILTER_SDF_EFFECTS ${ENABLE_FILTER_SDF_EFFECTS} CACHE BOOL "Enable SDF Effects Filter")
 set(${PropertyPrefix}ENABLE_FILTER_SHADER ${ENABLE_FILTER_SHADER} CACHE BOOL "Enable Shader Filter")
 set(${PropertyPrefix}ENABLE_FILTER_TRANSFORM ${ENABLE_FILTER_TRANSFORM} CACHE BOOL "Enable Transform Filter")
+## Sources
 set(${PropertyPrefix}ENABLE_SOURCE_MIRROR ${ENABLE_SOURCE_MIRROR} CACHE BOOL "Enable Mirror Source")
 set(${PropertyPrefix}ENABLE_SOURCE_SHADER ${ENABLE_SOURCE_SHADER} CACHE BOOL "Enable Shader Source")
+## Transitions
 set(${PropertyPrefix}ENABLE_TRANSITION_SHADER ${ENABLE_TRANSITION_SHADER} CACHE BOOL "Enable Shader Transition")
+## Debugging
+set(${PropertyPrefix}ENABLE_PROFILING FALSE CACHE BOOL "Enable CPU and GPU performance tracking, which has a non-zero overhead at all times. Do not enable this for release builds.")
 
 ################################################################################
 # CMake / Compiler Dependencies
@@ -803,6 +809,13 @@ if(${PropertyPrefix}ENABLE_TRANSITION_SHADER)
 	)
 	list(APPEND PROJECT_DEFINITIONS
 		ENABLE_TRANSITION_SHADER
+	)
+endif()
+
+## Features - Performance Profiling
+if(${PropertyPrefix}ENABLE_PROFILING)
+	list(APPEND PROJECT_DEFINITIONS
+		ENABLE_PROFILING
 	)
 endif()
 

--- a/source/filters/filter-displacement.cpp
+++ b/source/filters/filter-displacement.cpp
@@ -21,6 +21,7 @@
 #include "strings.hpp"
 #include <stdexcept>
 #include <sys/stat.h>
+#include "obs/gs/gs-helper.hpp"
 
 #define ST "Filter.Displacement"
 #define ST_FILE "Filter.Displacement.File"
@@ -94,6 +95,11 @@ void displacement_instance::video_render(gs_effect_t*)
 		obs_source_skip_video_filter(_self);
 		return;
 	}
+
+#ifdef ENABLE_PROFILING
+	gs::debug_marker gdmp{gs::debug_color_source, "Displacement Mapping '%s' on '%s'", obs_source_get_name(_self),
+						  obs_source_get_name(obs_filter_get_parent(_self))};
+#endif
 
 	if (!obs_source_process_filter_begin(_self, GS_RGBA, OBS_ALLOW_DIRECT_RENDERING)) {
 		obs_source_skip_video_filter(_self);

--- a/source/filters/filter-nv-face-tracking.hpp
+++ b/source/filters/filter-nv-face-tracking.hpp
@@ -74,7 +74,7 @@ namespace streamfx::filter::nvidia {
 		NvCVImage                                  _ar_image_bgr;
 		NvCVImage                                  _ar_image_temp;
 
-#ifdef _DEBUG
+#ifdef ENABLE_PROFILING
 		// Profiling
 		std::shared_ptr<util::profiler> _profile_capture;
 		std::shared_ptr<util::profiler> _profile_capture_realloc;
@@ -114,7 +114,7 @@ namespace streamfx::filter::nvidia {
 
 		virtual void video_render(gs_effect_t* effect) override;
 
-#ifdef _DEBUG
+#ifdef ENABLE_PROFILING
 		bool button_profile(obs_properties_t* props, obs_property_t* property);
 #endif
 	};

--- a/source/filters/filter-shader.cpp
+++ b/source/filters/filter-shader.cpp
@@ -85,9 +85,17 @@ void shader_instance::video_render(gs_effect_t* effect)
 		return;
 	}
 
+#ifdef ENABLE_PROFILING
+	gs::debug_marker gdmp{gs::debug_color_source, "Shader Filter '%s' on '%s'", obs_source_get_name(_self),
+						  obs_source_get_name(obs_filter_get_parent(_self))};
+#endif
+
 	{
-		gs::debug_marker _marker_cache{gs::debug_color_source, "%s: Capture", obs_source_get_name(_self)};
-		auto             op = _rt->render(_fx->width(), _fx->height());
+#ifdef ENABLE_PROFILING
+		gs::debug_marker gdm{gs::debug_color_source, "Cache"};
+#endif
+
+		auto op = _rt->render(_fx->width(), _fx->height());
 
 		gs_ortho(0, static_cast<float_t>(_fx->width()), 0, static_cast<float_t>(_fx->height()), -1, 1);
 
@@ -116,7 +124,9 @@ void shader_instance::video_render(gs_effect_t* effect)
 	}
 
 	{
-		gs::debug_marker _marker_cache{gs::debug_color_render, "%s: Render", obs_source_get_name(_self)};
+#ifdef ENABLE_PROFILING
+		gs::debug_marker gdm{gs::debug_color_render, "Render"};
+#endif
 
 		_fx->prepare_render();
 		_fx->set_input_a(_rt->get_texture());

--- a/source/gfx/blur/gfx-blur-box-linear.cpp
+++ b/source/gfx/blur/gfx-blur-box-linear.cpp
@@ -246,7 +246,10 @@ double_t gfx::blur::box_linear::get_step_scale_y()
 std::shared_ptr<::gs::texture> gfx::blur::box_linear::render()
 {
 	auto gctx = gs::context();
+
+#ifdef ENABLE_PROFILING
 	auto gdmp = gs::debug_marker(gs::debug_color_azure_radiance, "Box Linear Blur");
+#endif
 
 	float_t width  = float_t(_input_texture->get_width());
 	float_t height = float_t(_input_texture->get_height());
@@ -275,8 +278,11 @@ std::shared_ptr<::gs::texture> gfx::blur::box_linear::render()
 		effect.get_parameter("pSizeInverseMul").set_float(float_t(1.0f / (float_t(_size) * 2.0f + 1.0f)));
 
 		{
+#ifdef ENABLE_PROFILING
 			auto gdm = gs::debug_marker(gs::debug_color_azure_radiance, "Horizontal");
-			auto op  = _rendertarget2->render(uint32_t(width), uint32_t(height));
+#endif
+
+			auto op = _rendertarget2->render(uint32_t(width), uint32_t(height));
 			gs_ortho(0, 1., 0, 1., 0, 1.);
 			while (gs_effect_loop(effect.get_object(), "Draw")) {
 				gs_draw_sprite(nullptr, 0, 1, 1);
@@ -288,8 +294,11 @@ std::shared_ptr<::gs::texture> gfx::blur::box_linear::render()
 		effect.get_parameter("pImageTexel").set_float2(0., float_t(1.f / height));
 
 		{
+#ifdef ENABLE_PROFILING
 			auto gdm = gs::debug_marker(gs::debug_color_azure_radiance, "Vertical");
-			auto op  = _rendertarget->render(uint32_t(width), uint32_t(height));
+#endif
+
+			auto op = _rendertarget->render(uint32_t(width), uint32_t(height));
 			gs_ortho(0, 1., 0, 1., 0, 1.);
 			while (gs_effect_loop(effect.get_object(), "Draw")) {
 				gs_draw_sprite(nullptr, 0, 1, 1);
@@ -327,7 +336,10 @@ void gfx::blur::box_linear_directional::set_angle(double_t angle)
 std::shared_ptr<::gs::texture> gfx::blur::box_linear_directional::render()
 {
 	auto gctx = gs::context();
+
+#ifdef ENABLE_PROFILING
 	auto gdmp = gs::debug_marker(gs::debug_color_azure_radiance, "Box Linear Directional Blur");
+#endif
 
 	float_t width  = float_t(_input_texture->get_width());
 	float_t height = float_t(_input_texture->get_height());

--- a/source/gfx/blur/gfx-blur-box.cpp
+++ b/source/gfx/blur/gfx-blur-box.cpp
@@ -254,7 +254,10 @@ double_t gfx::blur::box::get_step_scale_y()
 std::shared_ptr<::gs::texture> gfx::blur::box::render()
 {
 	auto gctx = gs::context();
+
+#ifdef ENABLE_PROFILING
 	auto gdmp = gs::debug_marker(gs::debug_color_azure_radiance, "Box Blur");
+#endif
 
 	float_t width  = float_t(_input_texture->get_width());
 	float_t height = float_t(_input_texture->get_height());
@@ -283,8 +286,11 @@ std::shared_ptr<::gs::texture> gfx::blur::box::render()
 		effect.get_parameter("pSizeInverseMul").set_float(float_t(1.0f / (float_t(_size) * 2.0f + 1.0f)));
 
 		{
+#ifdef ENABLE_PROFILING
 			auto gdm = gs::debug_marker(gs::debug_color_azure_radiance, "Horizontal");
-			auto op  = _rendertarget2->render(uint32_t(width), uint32_t(height));
+#endif
+
+			auto op = _rendertarget2->render(uint32_t(width), uint32_t(height));
 			gs_ortho(0, 1., 0, 1., 0, 1.);
 			while (gs_effect_loop(effect.get_object(), "Draw")) {
 				gs_draw_sprite(nullptr, 0, 1, 1);
@@ -296,8 +302,11 @@ std::shared_ptr<::gs::texture> gfx::blur::box::render()
 		effect.get_parameter("pImageTexel").set_float2(0.f, float_t(1.f / height));
 
 		{
+#ifdef ENABLE_PROFILING
 			auto gdm = gs::debug_marker(gs::debug_color_azure_radiance, "Vertical");
-			auto op  = _rendertarget->render(uint32_t(width), uint32_t(height));
+#endif
+
+			auto op = _rendertarget->render(uint32_t(width), uint32_t(height));
 			gs_ortho(0, 1., 0, 1., 0, 1.);
 			while (gs_effect_loop(effect.get_object(), "Draw")) {
 				gs_draw_sprite(nullptr, 0, 1, 1);
@@ -335,7 +344,10 @@ void gfx::blur::box_directional::set_angle(double_t angle)
 std::shared_ptr<::gs::texture> gfx::blur::box_directional::render()
 {
 	auto gctx = gs::context();
+
+#ifdef ENABLE_PROFILING
 	auto gdmp = gs::debug_marker(gs::debug_color_azure_radiance, "Box Directional Blur");
+#endif
 
 	float_t width  = float_t(_input_texture->get_width());
 	float_t height = float_t(_input_texture->get_height());
@@ -407,7 +419,10 @@ void gfx::blur::box_rotational::set_angle(double_t angle)
 std::shared_ptr<::gs::texture> gfx::blur::box_rotational::render()
 {
 	auto gctx = gs::context();
+
+#ifdef ENABLE_PROFILING
 	auto gdmp = gs::debug_marker(gs::debug_color_azure_radiance, "Box Rotational Blur");
+#endif
 
 	float_t width  = float_t(_input_texture->get_width());
 	float_t height = float_t(_input_texture->get_height());
@@ -470,7 +485,10 @@ void gfx::blur::box_zoom::get_center(double_t& x, double_t& y)
 std::shared_ptr<::gs::texture> gfx::blur::box_zoom::render()
 {
 	auto gctx = gs::context();
+
+#ifdef ENABLE_PROFILING
 	auto gdmp = gs::debug_marker(gs::debug_color_azure_radiance, "Box Zoom Blur");
+#endif
 
 	float_t width  = float_t(_input_texture->get_width());
 	float_t height = float_t(_input_texture->get_height());

--- a/source/gfx/blur/gfx-blur-dual-filtering.cpp
+++ b/source/gfx/blur/gfx-blur-dual-filtering.cpp
@@ -229,7 +229,10 @@ void gfx::blur::dual_filtering::get_step_scale(double_t&, double_t&) {}
 std::shared_ptr<::gs::texture> gfx::blur::dual_filtering::render()
 {
 	auto gctx = gs::context();
+
+#ifdef ENABLE_PROFILING
 	auto gdmp = gs::debug_marker(gs::debug_color_azure_radiance, "Dual-Filtering Blur");
+#endif
 
 	auto effect = _data->get_effect();
 	if (!effect) {
@@ -256,14 +259,15 @@ std::shared_ptr<::gs::texture> gfx::blur::dual_filtering::render()
 
 	// Downsample
 	for (std::size_t n = 1; n <= actual_iterations; n++) {
-		// Idx 0 is a simply considered as a straight copy of the original and not rendered to.
+#ifdef ENABLE_PROFILING
 		auto gdm = gs::debug_marker(gs::debug_color_azure_radiance, "Down %lld", n);
+#endif
 
 		// Select Texture
 		std::shared_ptr<gs::texture> tex_cur;
 		if (n > 1) {
 			tex_cur = _rts[n - 1]->get_texture();
-		} else {
+		} else { // Idx 0 is a simply considered as a straight copy of the original and not rendered to.
 			tex_cur = _input_texture;
 		}
 
@@ -292,8 +296,9 @@ std::shared_ptr<::gs::texture> gfx::blur::dual_filtering::render()
 
 	// Upsample
 	for (std::size_t n = actual_iterations; n > 0; n--) {
-		// Idx max is a simply considered as a straight copy of the downscale and not rendered to.
+#ifdef ENABLE_PROFILING
 		auto gdm = gs::debug_marker(gs::debug_color_azure_radiance, "Up %lld", n);
+#endif
 
 		// Select Texture
 		std::shared_ptr<gs::texture> tex_in = _rts[n]->get_texture();

--- a/source/gfx/blur/gfx-blur-gaussian-linear.cpp
+++ b/source/gfx/blur/gfx-blur-gaussian-linear.cpp
@@ -292,7 +292,10 @@ double_t gfx::blur::gaussian_linear::get_step_scale_y()
 std::shared_ptr<::gs::texture> gfx::blur::gaussian_linear::render()
 {
 	auto gctx = gs::context();
+
+#ifdef ENABLE_PROFILING
 	auto gdmp = gs::debug_marker(gs::debug_color_azure_radiance, "Gaussian Linear Blur");
+#endif
 
 	gs::effect effect = _data->get_effect();
 	auto       kernel = _data->get_kernel(size_t(_size));
@@ -328,8 +331,11 @@ std::shared_ptr<::gs::texture> gfx::blur::gaussian_linear::render()
 		effect.get_parameter("pImageTexel").set_float2(float_t(1.f / width), 0.f);
 
 		{
+#ifdef ENABLE_PROFILING
 			auto gdm = gs::debug_marker(gs::debug_color_azure_radiance, "Horizontal");
-			auto op  = _rendertarget2->render(uint32_t(width), uint32_t(height));
+#endif
+
+			auto op = _rendertarget2->render(uint32_t(width), uint32_t(height));
 			gs_ortho(0, 1., 0, 1., 0, 1.);
 			while (gs_effect_loop(effect.get_object(), "Draw")) {
 				gs_draw_sprite(nullptr, 0, 1, 1);
@@ -345,8 +351,11 @@ std::shared_ptr<::gs::texture> gfx::blur::gaussian_linear::render()
 		effect.get_parameter("pImageTexel").set_float2(0.f, float_t(1.f / height));
 
 		{
+#ifdef ENABLE_PROFILING
 			auto gdm = gs::debug_marker(gs::debug_color_azure_radiance, "Vertical");
-			auto op  = _rendertarget2->render(uint32_t(width), uint32_t(height));
+#endif
+
+			auto op = _rendertarget2->render(uint32_t(width), uint32_t(height));
 			gs_ortho(0, 1., 0, 1., 0, 1.);
 			while (gs_effect_loop(effect.get_object(), "Draw")) {
 				gs_draw_sprite(nullptr, 0, 1, 1);
@@ -388,7 +397,10 @@ void gfx::blur::gaussian_linear_directional::set_angle(double_t angle)
 std::shared_ptr<::gs::texture> gfx::blur::gaussian_linear_directional::render()
 {
 	auto gctx = gs::context();
+
+#ifdef ENABLE_PROFILING
 	auto gdmp = gs::debug_marker(gs::debug_color_azure_radiance, "Gaussian Linear Directional Blur");
+#endif
 
 	gs::effect effect = _data->get_effect();
 	auto       kernel = _data->get_kernel(size_t(_size));

--- a/source/gfx/blur/gfx-blur-gaussian.cpp
+++ b/source/gfx/blur/gfx-blur-gaussian.cpp
@@ -298,7 +298,10 @@ double_t gfx::blur::gaussian::get_step_scale_y()
 std::shared_ptr<::gs::texture> gfx::blur::gaussian::render()
 {
 	auto gctx = gs::context();
+
+#ifdef ENABLE_PROFILING
 	auto gdmp = gs::debug_marker(gs::debug_color_azure_radiance, "Gaussian Blur");
+#endif
 
 	gs::effect effect = _data->get_effect();
 	auto       kernel = _data->get_kernel(size_t(_size));
@@ -334,8 +337,11 @@ std::shared_ptr<::gs::texture> gfx::blur::gaussian::render()
 		effect.get_parameter("pImageTexel").set_float2(float_t(1.f / width), 0.f);
 
 		{
+#ifdef ENABLE_PROFILING
 			auto gdm = gs::debug_marker(gs::debug_color_azure_radiance, "Horizontal");
-			auto op  = _rendertarget2->render(uint32_t(width), uint32_t(height));
+#endif
+
+			auto op = _rendertarget2->render(uint32_t(width), uint32_t(height));
 			gs_ortho(0, 1., 0, 1., 0, 1.);
 			while (gs_effect_loop(effect.get_object(), "Draw")) {
 				gs_draw_sprite(nullptr, 0, 1, 1);
@@ -351,8 +357,11 @@ std::shared_ptr<::gs::texture> gfx::blur::gaussian::render()
 		effect.get_parameter("pImageTexel").set_float2(0.f, float_t(1.f / height));
 
 		{
+#ifdef ENABLE_PROFILING
 			auto gdm = gs::debug_marker(gs::debug_color_azure_radiance, "Vertical");
-			auto op  = _rendertarget2->render(uint32_t(width), uint32_t(height));
+#endif
+
+			auto op = _rendertarget2->render(uint32_t(width), uint32_t(height));
 			gs_ortho(0, 1., 0, 1., 0, 1.);
 			while (gs_effect_loop(effect.get_object(), "Draw")) {
 				gs_draw_sprite(nullptr, 0, 1, 1);
@@ -394,7 +403,10 @@ void gfx::blur::gaussian_directional::set_angle(double_t angle)
 std::shared_ptr<::gs::texture> gfx::blur::gaussian_directional::render()
 {
 	auto gctx = gs::context();
+
+#ifdef ENABLE_PROFILING
 	auto gdmp = gs::debug_marker(gs::debug_color_azure_radiance, "Gaussian Directional Blur");
+#endif
 
 	gs::effect effect = _data->get_effect();
 	auto       kernel = _data->get_kernel(size_t(_size));
@@ -449,7 +461,10 @@ std::shared_ptr<::gs::texture> gfx::blur::gaussian_directional::render()
 std::shared_ptr<::gs::texture> gfx::blur::gaussian_rotational::render()
 {
 	auto gctx = gs::context();
+
+#ifdef ENABLE_PROFILING
 	auto gdmp = gs::debug_marker(gs::debug_color_azure_radiance, "Gaussian Rotational Blur");
+#endif
 
 	gs::effect effect = _data->get_effect();
 	auto       kernel = _data->get_kernel(size_t(_size));
@@ -527,7 +542,10 @@ void gfx::blur::gaussian_rotational::set_angle(double_t angle)
 std::shared_ptr<::gs::texture> gfx::blur::gaussian_zoom::render()
 {
 	auto gctx = gs::context();
+
+#ifdef ENABLE_PROFILING
 	auto gdmp = gs::debug_marker(gs::debug_color_azure_radiance, "Gaussian Zoom Blur");
+#endif
 
 	gs::effect effect = _data->get_effect();
 	auto       kernel = _data->get_kernel(size_t(_size));

--- a/source/gfx/gfx-source-texture.cpp
+++ b/source/gfx/gfx-source-texture.cpp
@@ -17,6 +17,7 @@
 
 #include "gfx-source-texture.hpp"
 #include <stdexcept>
+#include "obs/gs/gs-helper.hpp"
 
 gfx::source_texture::~source_texture()
 {
@@ -117,17 +118,17 @@ std::shared_ptr<gs::texture> gfx::source_texture::render(std::size_t width, std:
 		return nullptr;
 	}
 
-	{
-		GS_DEBUG_MARKER_BEGIN(GS_DEBUG_COLOR_ITEM, "gfx::source_texture");
+	if (_child) {
+#ifdef ENABLE_PROFILING
+		auto cctr =
+			gs::debug_marker(gs::debug_color_capture, "gfx::source_texture '%s'", obs_source_get_name(_child->get()));
+#endif
 		auto op = _rt->render((uint32_t)width, (uint32_t)height);
 		vec4 black;
 		vec4_zero(&black);
 		gs_ortho(0, (float_t)width, 0, (float_t)height, 0, 1);
 		gs_clear(GS_CLEAR_COLOR, &black, 0, 0);
-		if (_child) {
-			obs_source_video_render(_child->get());
-		}
-		GS_DEBUG_MARKER_END();
+		obs_source_video_render(_child->get());
 	}
 
 	std::shared_ptr<gs::texture> tex;

--- a/source/obs/gs/gs-helper.cpp
+++ b/source/obs/gs/gs-helper.cpp
@@ -29,7 +29,8 @@ gs::context::~context()
 	obs_leave_graphics();
 }
 
-gs::debug_marker::debug_marker(const float_t color[4], const char* format, ...)
+#ifdef ENABLE_PROFILING
+gs::debug_marker::debug_marker(const float color[4], const char* format, ...)
 {
 	std::size_t       size;
 	std::vector<char> buffer(128);
@@ -47,3 +48,4 @@ gs::debug_marker::~debug_marker()
 {
 	gs_debug_marker_end();
 }
+#endif

--- a/source/obs/gs/gs-helper.cpp
+++ b/source/obs/gs/gs-helper.cpp
@@ -29,11 +29,6 @@ gs::context::~context()
 	obs_leave_graphics();
 }
 
-/*gs::debug_marker::debug_marker(const float color[4], std::string name) : _name(name)
-{
-	gs_debug_marker_begin(color, _name.c_str());
-}*/
-
 gs::debug_marker::debug_marker(const float_t color[4], const char* format, ...)
 {
 	std::size_t       size;

--- a/source/obs/gs/gs-helper.hpp
+++ b/source/obs/gs/gs-helper.hpp
@@ -29,21 +29,22 @@ namespace gs {
 		~context();
 	};
 
-	static const float_t debug_color_white[4]           = {1.f, 1.f, 1.f, 1.f};
-	static const float_t debug_color_gray[4]            = {.5f, .5f, .5f, 1.f};
-	static const float_t debug_color_black[4]           = {0.f, 0.f, 0.f, 1.f};
-	static const float_t debug_color_red[4]             = {1.f, 0.f, 0.f, 1.f};
-	static const float_t debug_color_flush_orange[4]    = {1.f, .5f, 0.f, 1.f};
-	static const float_t debug_color_yellow[4]          = {1.f, 1.f, 0.f, 1.f};
-	static const float_t debug_color_chartreuse[4]      = {.5f, 1.f, 0.f, 1.f};
-	static const float_t debug_color_green[4]           = {0.f, 1.f, 0.f, 1.f};
-	static const float_t debug_color_spring_green[4]    = {0.f, 1.f, .5f, 1.f};
-	static const float_t debug_color_teal[4]            = {0.f, 1.f, 1.f, 1.f};
-	static const float_t debug_color_azure_radiance[4]  = {0.f, .5f, 1.f, 1.f};
-	static const float_t debug_color_blue[4]            = {0.f, 0.f, 1.f, 1.f};
-	static const float_t debug_color_electric_violet[4] = {.5f, 0.f, 1.f, 1.f};
-	static const float_t debug_color_magenta[4]         = {1.f, 0.f, 1.f, 1.f};
-	static const float_t debug_color_rose[4]            = {1.f, 0.f, .5f, 1.f};
+#ifdef ENABLE_PROFILING
+	static constexpr float_t debug_color_white[4]           = {1.f, 1.f, 1.f, 1.f};
+	static constexpr float_t debug_color_gray[4]            = {.5f, .5f, .5f, 1.f};
+	static constexpr float_t debug_color_black[4]           = {0.f, 0.f, 0.f, 1.f};
+	static constexpr float_t debug_color_red[4]             = {1.f, 0.f, 0.f, 1.f};
+	static constexpr float_t debug_color_flush_orange[4]    = {1.f, .5f, 0.f, 1.f};
+	static constexpr float_t debug_color_yellow[4]          = {1.f, 1.f, 0.f, 1.f};
+	static constexpr float_t debug_color_chartreuse[4]      = {.5f, 1.f, 0.f, 1.f};
+	static constexpr float_t debug_color_green[4]           = {0.f, 1.f, 0.f, 1.f};
+	static constexpr float_t debug_color_spring_green[4]    = {0.f, 1.f, .5f, 1.f};
+	static constexpr float_t debug_color_teal[4]            = {0.f, 1.f, 1.f, 1.f};
+	static constexpr float_t debug_color_azure_radiance[4]  = {0.f, .5f, 1.f, 1.f};
+	static constexpr float_t debug_color_blue[4]            = {0.f, 0.f, 1.f, 1.f};
+	static constexpr float_t debug_color_electric_violet[4] = {.5f, 0.f, 1.f, 1.f};
+	static constexpr float_t debug_color_magenta[4]         = {1.f, 0.f, 1.f, 1.f};
+	static constexpr float_t debug_color_rose[4]            = {1.f, 0.f, .5f, 1.f};
 
 	static const float_t* debug_color_source       = debug_color_white;
 	static const float_t* debug_color_capture      = debug_color_flush_orange;
@@ -62,4 +63,5 @@ namespace gs {
 		debug_marker(const float_t color[4], const char* format, ...);
 		~debug_marker();
 	};
+#endif
 } // namespace gs

--- a/source/obs/gs/gs-mipmapper.cpp
+++ b/source/obs/gs/gs-mipmapper.cpp
@@ -137,7 +137,10 @@ void gs::mipmapper::rebuild(std::shared_ptr<gs::texture> source, std::shared_ptr
 			size_t   max_mip_level = 1;
 
 			{
+#ifdef ENABLE_PROFILING
 				auto cctr = gs::debug_marker(gs::debug_color_azure_radiance, "Mip Level %lld", 0);
+#endif
+
 #ifdef _WIN32
 				if (gs_get_device_type() == GS_DEVICE_DIRECT3D_11) {
 					{ // Retrieve maximum mip map level.
@@ -161,7 +164,9 @@ void gs::mipmapper::rebuild(std::shared_ptr<gs::texture> source, std::shared_ptr
 
 			// Render each mip map level.
 			for (size_t mip = 1; mip < max_mip_level; mip++) {
+#ifdef ENABLE_PROFILING
 				auto cctr = gs::debug_marker(gs::debug_color_azure_radiance, "Mip Level %lld", mip);
+#endif
 
 				uint32_t cwidth  = std::max<uint32_t>(width >> mip, 1);
 				uint32_t cheight = std::max<uint32_t>(height >> mip, 1);

--- a/source/sources/source-mirror.cpp
+++ b/source/sources/source-mirror.cpp
@@ -141,6 +141,11 @@ void mirror_instance::video_render(gs_effect_t* effect)
 	if ((obs_source_get_output_flags(_source.get()) & OBS_SOURCE_VIDEO) == 0)
 		return;
 
+#ifdef ENABLE_PROFILING
+	gs::debug_marker gdmp{gs::debug_color_source, "Source Mirror '%s' for '%s'", obs_source_get_name(_self),
+						  obs_source_get_name(_source.get())};
+#endif
+
 	obs_source_video_render(_source.get());
 }
 

--- a/source/sources/source-shader.cpp
+++ b/source/sources/source-shader.cpp
@@ -20,6 +20,7 @@
 #include "source-shader.hpp"
 #include "strings.hpp"
 #include <stdexcept>
+#include "obs/gs/gs-helper.hpp"
 #include "utility.hpp"
 
 #define ST "Source.Shader"
@@ -78,6 +79,10 @@ void shader_instance::video_render(gs_effect_t* effect)
 	if (!_fx) {
 		return;
 	}
+
+#ifdef ENABLE_PROFILING
+	gs::debug_marker gdmp{gs::debug_color_source, "Shader Source '%s'", obs_source_get_name(_self)};
+#endif
 
 	_fx->prepare_render();
 	_fx->render();

--- a/source/transitions/transition-shader.cpp
+++ b/source/transitions/transition-shader.cpp
@@ -20,6 +20,7 @@
 #include "transition-shader.hpp"
 #include "strings.hpp"
 #include <stdexcept>
+#include "obs/gs/gs-helper.hpp"
 #include "utility.hpp"
 
 #define ST "Transition.Shader"
@@ -80,6 +81,10 @@ void shader_instance::video_render(gs_effect_t* effect)
 	if (!_fx) {
 		return;
 	}
+
+#ifdef ENABLE_PROFILING
+	gs::debug_marker gdmp{gs::debug_color_source, "Shader Transition '%s'", obs_source_get_name(_self)};
+#endif
 
 	_fx->prepare_render();
 	obs_transition_video_render(


### PR DESCRIPTION
<!-- Hi, thank you for taking the time to submit a pull request. -->
<!-- Please make sure that you fill this out in it's entirety. -->

### Description
Adds a new CMake option "ENABLE_PROFILING" which enables all CPU and GPU performance profiling available in StreamFX for tracking what's actually causing things to be slow. This option defaults to off, so release builds are not impacted by this.
<!-- Describe your changes in as much detail as possible. -->
<!-- But please exclude your personal history from this. Only describe the changes -->

### Related Issues
- #199 Look into additional optimizations.
- #150 Downscaling for Nvidia Face Tracking
<!-- - #0000 Name of Issue -->
<!-- - #0001 Name of Issue -->
