### PR TITLE
Allow inlining various functions

### DIFF
--- a/source/obs/gs/gs-helper.cpp
+++ b/source/obs/gs/gs-helper.cpp
@@ -18,34 +18,3 @@
  */
 
 #include "gs-helper.hpp"
-
-gs::context::context()
-{
-	obs_enter_graphics();
-}
-
-gs::context::~context()
-{
-	obs_leave_graphics();
-}
-
-#ifdef ENABLE_PROFILING
-gs::debug_marker::debug_marker(const float color[4], const char* format, ...)
-{
-	std::size_t       size;
-	std::vector<char> buffer(64);
-
-	va_list vargs;
-	va_start(vargs, format);
-	size = static_cast<size_t>(vsnprintf(buffer.data(), buffer.size(), format, vargs));
-	va_end(vargs);
-
-	_name = std::string(buffer.data(), buffer.data() + size);
-	gs_debug_marker_begin(color, _name.c_str());
-}
-
-gs::debug_marker::~debug_marker()
-{
-	gs_debug_marker_end();
-}
-#endif

--- a/source/obs/gs/gs-helper.hpp
+++ b/source/obs/gs/gs-helper.hpp
@@ -1,6 +1,6 @@
 /*
  * Modern effects for a modern Streamer
- * Copyright (C) 2017 Michael Fabian Dirks
+ * Copyright (C) 2020 Michael Fabian Dirks
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -25,8 +25,14 @@
 namespace gs {
 	class context {
 		public:
-		context();
-		~context();
+		inline context()
+		{
+			obs_enter_graphics();
+		}
+		~context()
+		{
+			obs_leave_graphics();
+		}
 	};
 
 #ifdef ENABLE_PROFILING
@@ -59,9 +65,24 @@ namespace gs {
 		std::string _name;
 
 		public:
-		//debug_marker(const float color[4], std::string name);
-		debug_marker(const float_t color[4], const char* format, ...);
-		~debug_marker();
+		inline debug_marker(const float_t color[4], const char* format, ...)
+		{
+			std::size_t       size;
+			std::vector<char> buffer(64);
+
+			va_list vargs;
+			va_start(vargs, format);
+			size = static_cast<size_t>(vsnprintf(buffer.data(), buffer.size(), format, vargs));
+			va_end(vargs);
+
+			_name = std::string(buffer.data(), buffer.data() + size);
+			gs_debug_marker_begin(color, _name.c_str());
+		}
+
+		inline ~debug_marker()
+		{
+			gs_debug_marker_end();
+		}
 	};
 #endif
 } // namespace gs


### PR DESCRIPTION
<!-- Hi, thank you for taking the time to submit a pull request. -->
<!-- Please make sure that you fill this out in it's entirety. -->

### Description
Allows compilers to inline functions without requiring link time code generation to be enabled, slightly improving performance for these functions.

### Related Issues
<!-- - #0000 Name of Issue -->
<!-- - #0001 Name of Issue -->
