### PR TITLE
NVIDIA Face Tracking Filter: Reduce impact on games, asynchronous tracking, and more

### DIFF
--- a/data/locale/en-US.ini
+++ b/data/locale/en-US.ini
@@ -220,7 +220,7 @@ Filter.DynamicMask.Channel.Input="%s Input Value"
 Filter.DynamicMask.Channel.Input.Description="The input value for channel %s.\nSets 'value[%s][%s]' in the calculation 'mask[%s] = (base[%s] + value[%s][Red] * source[Red] + value[%s][Green] * source[Green] + value[%s][Blue] * source[Blue] + value[%s][Alpha] * source[Alpha]) * multiplier[%s]'."
 
 # Filter - Nvidia Face Tracking
-Filter.Nvidia.FaceTracking="Nvidia Face Tracking"
+Filter.Nvidia.FaceTracking="NVIDIA Face Tracking"
 Filter.Nvidia.FaceTracking.ROI="Region of Interest"
 Filter.Nvidia.FaceTracking.ROI.Zoom="Zoom"
 Filter.Nvidia.FaceTracking.ROI.Zoom.Description="Restrict the maximum zoom level based on the current maximum and minimum zoom level.\nValues above 100% zoom into the face, while values below 100% will keep their distance from the face."

--- a/source/nvidia/cuda/nvidia-cuda-context.cpp
+++ b/source/nvidia/cuda/nvidia-cuda-context.cpp
@@ -71,8 +71,6 @@ nvidia::cuda::context::context(std::shared_ptr<::nvidia::cuda::cuda> cuda, ID3D1
 		throw std::runtime_error("Failed to acquire primary device context.");
 	}
 
-	_cuda->cuDevicePrimaryCtxSetFlags(_device, cu_context_flags::SCHEDULER_YIELD);
-
 	_has_device = true;
 }
 #endif

--- a/source/nvidia/cuda/nvidia-cuda-context.hpp
+++ b/source/nvidia/cuda/nvidia-cuda-context.hpp
@@ -27,8 +27,8 @@ namespace nvidia::cuda {
 		::nvidia::cuda::cu_context_t          _ctx;
 
 		// Primary Device Context
-		bool         _has_device;
-		std::int32_t _device;
+		bool                        _has_device;
+		::nvidia::cuda::cu_device_t _device;
 
 		private:
 		context(std::shared_ptr<::nvidia::cuda::cuda> cuda);

--- a/source/nvidia/cuda/nvidia-cuda.cpp
+++ b/source/nvidia/cuda/nvidia-cuda.cpp
@@ -64,12 +64,14 @@ nvidia::cuda::cuda::cuda()
 	CUDA_LOAD_SYMBOL_V2(cuDevicePrimaryCtxSetFlags);
 
 	// Context Management
+	CUDA_LOAD_SYMBOL_V2(cuCtxCreate);
 	CUDA_LOAD_SYMBOL_V2(cuCtxDestroy);
 	CUDA_LOAD_SYMBOL(cuCtxGetCurrent);
 	CUDA_LOAD_SYMBOL(cuCtxGetStreamPriorityRange);
 	CUDA_LOAD_SYMBOL_V2(cuCtxPopCurrent);
 	CUDA_LOAD_SYMBOL_V2(cuCtxPushCurrent);
 	CUDA_LOAD_SYMBOL(cuCtxSetCurrent);
+	CUDA_LOAD_SYMBOL(cuCtxSynchronize);
 
 	// Memory Management
 	CUDA_LOAD_SYMBOL_V2(cuArrayGetDescriptor);

--- a/source/nvidia/cuda/nvidia-cuda.hpp
+++ b/source/nvidia/cuda/nvidia-cuda.hpp
@@ -160,7 +160,7 @@ namespace nvidia::cuda {
 		CUDA_DEFINE_FUNCTION(cuDevicePrimaryCtxSetFlags, cu_device_t device, cu_context_flags flags);
 
 		// Context Management
-		// cuCtxCreate_v2
+		CUDA_DEFINE_FUNCTION(cuCtxCreate, cu_context_t* ctx, cu_context_flags flags, cu_device_t device);
 		CUDA_DEFINE_FUNCTION(cuCtxDestroy, cu_context_t ctx);
 		// cuCtxGetApiVersion
 		// cuCtxGetCacheConfig
@@ -177,6 +177,7 @@ namespace nvidia::cuda {
 		// cuCtxSetLimit
 		// cuCtxSetSharedMemConfig
 		// cuCtxSynchronize
+		CUDA_DEFINE_FUNCTION(cuCtxSynchronize);
 		// UNDOCUMENTED? cuCtxResetPersistingL2Cache
 
 		// Module Management
@@ -395,7 +396,7 @@ namespace nvidia::cuda {
 		// cuGraphicsD3D10RegisterResource
 
 		// Direct3D11 Interopability
-		CUDA_DEFINE_FUNCTION(cuD3D11GetDevice, std::int32_t* device, IDXGIAdapter* adapter);
+		CUDA_DEFINE_FUNCTION(cuD3D11GetDevice, cu_device_t* device, IDXGIAdapter* adapter);
 		// cuD3D11GetDevices
 		CUDA_DEFINE_FUNCTION(cuGraphicsD3D11RegisterResource, cu_graphics_resource_t* resource,
 							 ID3D11Resource* d3dresource, std::uint32_t flags);


### PR DESCRIPTION
### Description
Moves geometry and filtering into the video tick call, which happens much more frequently than the tracking updates, allowing for smoother continuous tracking. As filtering is no longer happening in the tracking thread, an additional velocity variable was added in order to smooth over time periods where tracking is not in sync with rendering, or otherwise delayed. 

Furthermore all the tracking values are now in 0..1 space, or UVs, which simplifies the logic necessary to render things, while slightly increasing the cost of the math in the tracking thread. This was combined with the fix to #206, which should now work properly again.

Also removes the high priority CUDA stream as it just causes collisions with NVENC and OBS rendering, which is not what we want. 

### Related Issues
- Fixes #206 Filter changes size depending on what's after it.
<!-- - #0000 Name of Issue -->
<!-- - #0001 Name of Issue -->
