### PR TITLE
configuration: Fix failed saving due to invalid path

### DIFF
--- a/source/configuration.cpp
+++ b/source/configuration.cpp
@@ -33,8 +33,7 @@ streamfx::configuration::~configuration()
 		if (_config_path.has_parent_path()) {
 			std::filesystem::create_directories(_config_path.parent_path());
 		}
-		if (!obs_data_save_json_safe(_data.get(), _config_path.string().c_str(), ".tmp",
-									 _config_backup_path.string().c_str())) {
+		if (!obs_data_save_json_safe(_data.get(), _config_path.string().c_str(), ".tmp", path_backup_ext.data())) {
 			throw std::exception();
 		}
 	} catch (...) {
@@ -42,20 +41,18 @@ streamfx::configuration::~configuration()
 	}
 }
 
-streamfx::configuration::configuration() : _data(), _config_path(), _config_backup_path()
+streamfx::configuration::configuration() : _data(), _config_path()
 {
 	{ // Retrieve global configuration path.
 		const char* path    = obs_module_config_path("config.json");
 		_config_path        = path;
-		_config_backup_path = std::filesystem::path(_config_path).concat(path_backup_ext);
 	}
 
 	try {
 		if (!std::filesystem::exists(_config_path) || !std::filesystem::is_regular_file(_config_path)) {
 			throw std::exception();
 		} else {
-			obs_data_t* data = obs_data_create_from_json_file_safe(_config_path.string().c_str(),
-																   _config_backup_path.string().c_str());
+			obs_data_t* data = obs_data_create_from_json_file_safe(_config_path.string().c_str(), path_backup_ext.data());
 			if (!data) {
 				throw std::exception();
 			} else {

--- a/source/configuration.hpp
+++ b/source/configuration.hpp
@@ -27,7 +27,6 @@ namespace streamfx {
 		std::shared_ptr<obs_data_t> _data;
 
 		std::filesystem::path _config_path;
-		std::filesystem::path _config_backup_path;
 
 		public:
 		~configuration();


### PR DESCRIPTION
<!-- Hi, thank you for taking the time to submit a pull request. -->
<!-- Please make sure that you fill this out in it's entirety. -->

### Description
Fixes saving the configuration when a configuration file already exists.
<!-- Describe your changes in as much detail as possible. -->
<!-- But please exclude your personal history from this. Only describe the changes -->

### Related Issues
<!-- - #0000 Name of Issue -->
<!-- - #0001 Name of Issue -->
