### PR TITLE
Allow regristration of Proxy sources/filters/transitions

### DIFF
--- a/source/common.hpp
+++ b/source/common.hpp
@@ -33,12 +33,15 @@
 // Common C++ includes
 #include <algorithm>
 #include <limits>
+#include <map>
 #include <memory>
+#include <set>
 #include <stdexcept>
 #include <string>
 #include <string_view>
 #include <type_traits>
 #include <utility>
+#include <vector>
 
 // Common Plugin includes
 #include "strings.hpp"

--- a/source/filters/filter-blur.cpp
+++ b/source/filters/filter-blur.cpp
@@ -561,12 +561,13 @@ void blur_instance::video_render(gs_effect_t* effect)
 
 blur_factory::blur_factory()
 {
-	_info.id           = "obs-stream-effects-filter-blur";
+	_info.id           = PREFIX "filter-blur";
 	_info.type         = OBS_SOURCE_TYPE_FILTER;
 	_info.output_flags = OBS_SOURCE_VIDEO;
 
 	set_resolution_enabled(false);
 	finish_setup();
+	register_proxy("obs-stream-effects-filter-blur");
 }
 
 blur_factory::~blur_factory() {}

--- a/source/filters/filter-color-grade.cpp
+++ b/source/filters/filter-color-grade.cpp
@@ -274,12 +274,13 @@ void color_grade_instance::video_render(gs_effect_t* effect)
 
 color_grade_factory::color_grade_factory()
 {
-	_info.id           = "obs-stream-effects-filter-color-grade";
+	_info.id           = PREFIX "filter-color-grade";
 	_info.type         = OBS_SOURCE_TYPE_FILTER;
 	_info.output_flags = OBS_SOURCE_VIDEO;
 
 	set_resolution_enabled(false);
 	finish_setup();
+	register_proxy("obs-stream-effects-filter-color-grade");
 }
 
 color_grade_factory::~color_grade_factory() {}

--- a/source/filters/filter-displacement.cpp
+++ b/source/filters/filter-displacement.cpp
@@ -123,12 +123,13 @@ std::string displacement_instance::get_file()
 
 displacement_factory::displacement_factory()
 {
-	_info.id           = "obs-stream-effects-filter-displacement";
+	_info.id           = PREFIX "filter-displacement";
 	_info.type         = OBS_SOURCE_TYPE_FILTER;
 	_info.output_flags = OBS_SOURCE_VIDEO;
 
 	set_resolution_enabled(false);
 	finish_setup();
+	register_proxy("obs-stream-effects-filter-displacement");
 }
 
 displacement_factory::~displacement_factory() {}

--- a/source/filters/filter-dynamic-mask.cpp
+++ b/source/filters/filter-dynamic-mask.cpp
@@ -346,12 +346,13 @@ void dynamic_mask_instance::video_render(gs_effect_t* in_effect)
 
 dynamic_mask_factory::dynamic_mask_factory()
 {
-	_info.id           = "obs-stream-effects-filter-dynamic-mask";
+	_info.id           = PREFIX "filter-dynamic-mask";
 	_info.type         = OBS_SOURCE_TYPE_FILTER;
 	_info.output_flags = OBS_SOURCE_VIDEO;
 
 	set_resolution_enabled(false);
 	finish_setup();
+	register_proxy("obs-stream-effects-filter-dynamic-mask");
 }
 
 dynamic_mask_factory::~dynamic_mask_factory() {}

--- a/source/filters/filter-nv-face-tracking.cpp
+++ b/source/filters/filter-nv-face-tracking.cpp
@@ -626,12 +626,13 @@ face_tracking_factory::face_tracking_factory()
 	}
 
 	// Info
-	_info.id           = "streamfx-nvidia-face-tracking";
+	_info.id           = PREFIX "filter-nvidia-face-tracking";
 	_info.type         = OBS_SOURCE_TYPE_FILTER;
 	_info.output_flags = OBS_SOURCE_VIDEO;
 
 	set_resolution_enabled(false);
 	finish_setup();
+	register_proxy("streamfx-nvidia-face-tracking");
 }
 
 face_tracking_factory::~face_tracking_factory() {}

--- a/source/filters/filter-sdf-effects.cpp
+++ b/source/filters/filter-sdf-effects.cpp
@@ -520,12 +520,13 @@ void sdf_effects_instance::video_render(gs_effect_t* effect)
 
 sdf_effects_factory::sdf_effects_factory()
 {
-	_info.id           = "obs-stream-effects-filter-sdf-effects";
+	_info.id           = PREFIX "filter-sdf-effects";
 	_info.type         = OBS_SOURCE_TYPE_FILTER;
 	_info.output_flags = OBS_SOURCE_VIDEO;
 
 	set_resolution_enabled(false);
 	finish_setup();
+	register_proxy("obs-stream-effects-filter-sdf-effects");
 }
 
 sdf_effects_factory::~sdf_effects_factory() {}

--- a/source/filters/filter-shader.cpp
+++ b/source/filters/filter-shader.cpp
@@ -136,11 +136,12 @@ void shader_instance::video_render(gs_effect_t* effect)
 
 shader_factory::shader_factory()
 {
-	_info.id           = "obs-stream-effects-filter-shader";
+	_info.id           = PREFIX "filter-shader";
 	_info.type         = OBS_SOURCE_TYPE_FILTER;
 	_info.output_flags = OBS_SOURCE_VIDEO | OBS_SOURCE_CUSTOM_DRAW;
 
 	finish_setup();
+	register_proxy("obs-stream-effects-filter-shader");
 }
 
 shader_factory::~shader_factory() {}

--- a/source/filters/filter-transform.cpp
+++ b/source/filters/filter-transform.cpp
@@ -439,12 +439,13 @@ void transform_instance::video_render(gs_effect_t* effect)
 
 transform_factory::transform_factory()
 {
-	_info.id           = "obs-stream-effects-filter-transform";
+	_info.id           = PREFIX "filter-transform";
 	_info.type         = OBS_SOURCE_TYPE_FILTER;
 	_info.output_flags = OBS_SOURCE_VIDEO;
 
 	set_resolution_enabled(false);
 	finish_setup();
+	register_proxy("obs-stream-effects-filter-transform");
 }
 
 transform_factory::~transform_factory() {}

--- a/source/sources/source-mirror.cpp
+++ b/source/sources/source-mirror.cpp
@@ -268,13 +268,14 @@ void mirror_instance::audio_output(std::shared_ptr<void> data)
 
 mirror_factory::mirror_factory()
 {
-	_info.id           = "obs-stream-effects-source-mirror";
+	_info.id           = PREFIX "source-mirror";
 	_info.type         = OBS_SOURCE_TYPE_INPUT;
 	_info.output_flags = OBS_SOURCE_VIDEO | OBS_SOURCE_CUSTOM_DRAW | OBS_SOURCE_AUDIO;
 
 	set_have_active_child_sources(true);
 	set_have_child_sources(true);
 	finish_setup();
+	register_proxy("obs-stream-effects-source-mirror");
 }
 
 mirror_factory::~mirror_factory() {}

--- a/source/sources/source-shader.cpp
+++ b/source/sources/source-shader.cpp
@@ -90,11 +90,12 @@ void shader_instance::video_render(gs_effect_t* effect)
 
 shader_factory::shader_factory()
 {
-	_info.id           = "obs-stream-effects-source-shader";
+	_info.id           = PREFIX "source-shader";
 	_info.type         = OBS_SOURCE_TYPE_INPUT;
 	_info.output_flags = OBS_SOURCE_VIDEO | OBS_SOURCE_CUSTOM_DRAW;
 
 	finish_setup();
+	register_proxy("obs-stream-effects-source-shader");
 }
 
 shader_factory::~shader_factory() {}

--- a/source/strings.hpp
+++ b/source/strings.hpp
@@ -21,6 +21,7 @@
 #include "common.hpp"
 
 #define PLUGIN_NAME "StreamFX"
+#define PREFIX "streamfx-"
 
 #define D_TRANSLATE(x) obs_module_text(x)
 #define D_DESC(x) x ".Description"

--- a/source/transitions/transition-shader.cpp
+++ b/source/transitions/transition-shader.cpp
@@ -116,11 +116,12 @@ void shader_instance::transition_stop() {}
 
 shader_factory::shader_factory()
 {
-	_info.id           = "obs-stream-effects-transition-shader";
+	_info.id           = PREFIX "transition-shader";
 	_info.type         = OBS_SOURCE_TYPE_TRANSITION;
 	_info.output_flags = OBS_SOURCE_VIDEO | OBS_SOURCE_CUSTOM_DRAW;
 
 	finish_setup();
+	register_proxy("obs-stream-effects-transition-shader");
 }
 
 shader_factory::~shader_factory() {}


### PR DESCRIPTION
<!-- Hi, thank you for taking the time to submit a pull request. -->
<!-- Please make sure that you fill this out in it's entirety. -->

### Description
Enables the use of proxy registrations to maintain compatibility with older versions.

While newer versions of the plugin would stay compatible, older versions might use an incorrect or outdated id to identify themselves - therefore changing the id would break configurations. With this fix we can register both and have the old id as a hidden handler for the old registrations.
<!-- Describe your changes in as much detail as possible. -->
<!-- But please exclude your personal history from this. Only describe the changes -->

### Related Issues
<!-- - #0000 Name of Issue -->
<!-- - #0001 Name of Issue -->
