### PR TITLE
obs/encoder-factory: Fix incorrect proxy registration

### DIFF
--- a/source/obs/obs-encoder-factory.hpp
+++ b/source/obs/obs-encoder-factory.hpp
@@ -82,8 +82,8 @@ namespace obs {
 			// Create proxy.
 			std::shared_ptr<obs_encoder_info> proxy = std::make_shared<obs_encoder_info>();
 			memcpy(proxy.get(), &_info, sizeof(obs_encoder_info));
-			_info.id = iter.first->c_str();
-			_info.caps |= OBS_SOURCE_DEPRECATED;
+			proxy->id = iter.first->c_str();
+			proxy->caps |= OBS_ENCODER_CAP_DEPRECATED;
 			obs_register_encoder(proxy.get());
 
 			_proxies.emplace(name, proxy);


### PR DESCRIPTION
<!-- Hi, thank you for taking the time to submit a pull request. -->
<!-- Please make sure that you fill this out in it's entirety. -->

### Description
Fixes a typo in the code that caused the proxy registration to modify the original object, flooding the encoder list with entries.
<!-- Describe your changes in as much detail as possible. -->
<!-- But please exclude your personal history from this. Only describe the changes -->

### Related Issues
<!-- - #0000 Name of Issue -->
<!-- - #0001 Name of Issue -->
