### PR TITLE
Rename LOG_ to DLOG_ in order to prevent ambigious macro names

### DIFF
--- a/source/common.hpp
+++ b/source/common.hpp
@@ -85,11 +85,11 @@ extern "C" {
 
 // Common Global defines
 /// Logging
-#define LOG_(level, ...) blog(level, "[" PLUGIN_NAME "] " __VA_ARGS__)
-#define LOG_ERROR(...) LOG_(LOG_ERROR, __VA_ARGS__)
-#define LOG_WARNING(...) LOG_(LOG_WARNING, __VA_ARGS__)
-#define LOG_INFO(...) LOG_(LOG_INFO, __VA_ARGS__)
-#define LOG_DEBUG(...) LOG_(LOG_DEBUG, __VA_ARGS__)
+#define DLOG_(level, ...) blog(level, "[" PLUGIN_NAME "] " __VA_ARGS__)
+#define DLOG_ERROR(...) DLOG_(LOG_ERROR, __VA_ARGS__)
+#define DLOG_WARNING(...) DLOG_(LOG_WARNING, __VA_ARGS__)
+#define DLOG_INFO(...) DLOG_(LOG_INFO, __VA_ARGS__)
+#define DLOG_DEBUG(...) DLOG_(LOG_DEBUG, __VA_ARGS__)
 /// Currrent function name (as const char*)
 #ifdef _MSC_VER
 // Microsoft Visual Studio

--- a/source/configuration.cpp
+++ b/source/configuration.cpp
@@ -37,7 +37,7 @@ streamfx::configuration::~configuration()
 			throw std::exception();
 		}
 	} catch (...) {
-		LOG_ERROR("Failed to save configuration, next start will be using defaults or backed up configuration.");
+		DLOG_ERROR("Failed to save configuration, next start will be using defaults or backed up configuration.");
 	}
 }
 

--- a/source/encoders/handlers/debug_handler.cpp
+++ b/source/encoders/handlers/debug_handler.cpp
@@ -78,7 +78,7 @@ void debug_handler::get_properties(obs_properties_t*, const AVCodec* codec, AVCo
 		return;
 	}
 
-	LOG_INFO("Options for '%s':", codec->name);
+	DLOG_INFO("Options for '%s':", codec->name);
 
 	std::pair<AVOptionType, std::string> opt_type_name[] = {
 		{AV_OPT_TYPE_FLAGS, "Flags"},
@@ -115,11 +115,11 @@ void debug_handler::get_properties(obs_properties_t*, const AVCodec* codec, AVCo
 
 		if (opt->type == AV_OPT_TYPE_CONST) {
 			if (opt->unit == nullptr) {
-				LOG_INFO("  Constant '%s' and help text '%s' with unknown settings.", opt->name, opt->help);
+				DLOG_INFO("  Constant '%s' and help text '%s' with unknown settings.", opt->name, opt->help);
 			} else {
 				auto unit_type = unit_types.find(opt->unit);
 				if (unit_type == unit_types.end()) {
-					LOG_INFO("  [%s] Flag '%s' and help text '%s' with value '%lld'.", opt->unit, opt->name, opt->help,
+					DLOG_INFO("  [%s] Flag '%s' and help text '%s' with value '%lld'.", opt->unit, opt->name, opt->help,
 							 opt->default_val.i64);
 				} else {
 					std::string out;
@@ -147,7 +147,7 @@ void debug_handler::get_properties(obs_properties_t*, const AVCodec* codec, AVCo
 						break;
 					}
 
-					LOG_INFO("  [%s] Constant '%s' and help text '%s' with value '%s'.", opt->unit, opt->name,
+					DLOG_INFO("  [%s] Constant '%s' and help text '%s' with value '%s'.", opt->unit, opt->name,
 							 opt->help, out.c_str());
 				}
 			}
@@ -185,7 +185,7 @@ void debug_handler::get_properties(obs_properties_t*, const AVCodec* codec, AVCo
 				}
 			}
 
-			LOG_INFO(
+			DLOG_INFO(
 				"  Option '%s'%s%s%s with help '%s' of type '%s' with default value '%s', minimum '%s' and maximum "
 				"'%s'.",
 				opt->name, opt->unit ? " with unit (" : "", opt->unit ? opt->unit : "", opt->unit ? ")" : "", opt->help,

--- a/source/encoders/handlers/nvenc_h264_handler.cpp
+++ b/source/encoders/handlers/nvenc_h264_handler.cpp
@@ -132,7 +132,7 @@ void nvenc_h264_handler::log_options(obs_data_t* settings, const AVCodec* codec,
 {
 	nvenc::log_options(settings, codec, context);
 
-	LOG_INFO("[%s]     H.264/AVC:", codec->name);
+	DLOG_INFO("[%s]     H.264/AVC:", codec->name);
 	::ffmpeg::tools::print_av_option_string(context, "profile", "      Profile", [](int64_t v) {
 		profile val   = static_cast<profile>(v);
 		auto    index = profiles.find(val);

--- a/source/encoders/handlers/nvenc_hevc_handler.cpp
+++ b/source/encoders/handlers/nvenc_hevc_handler.cpp
@@ -138,7 +138,7 @@ void nvenc_hevc_handler::log_options(obs_data_t* settings, const AVCodec* codec,
 {
 	nvenc::log_options(settings, codec, context);
 
-	LOG_INFO("[%s]     H.265/HEVC:", codec->name);
+	DLOG_INFO("[%s]     H.265/HEVC:", codec->name);
 	::ffmpeg::tools::print_av_option_string(context, "profile", "      Profile", [](int64_t v) {
 		profile val   = static_cast<profile>(v);
 		auto    index = profiles.find(val);

--- a/source/encoders/handlers/nvenc_shared.cpp
+++ b/source/encoders/handlers/nvenc_shared.cpp
@@ -680,7 +680,7 @@ void nvenc::update(obs_data_t* settings, const AVCodec* codec, AVCodecContext* c
 
 		int64_t wp = obs_data_get_int(settings, KEY_OTHER_WEIGHTEDPREDICTION);
 		if ((context->max_b_frames > 0) && util::is_tristate_enabled(wp)) {
-			LOG_WARNING("[%s] Weighted Prediction disabled because of B-Frames being used.", codec->name);
+			DLOG_WARNING("[%s] Weighted Prediction disabled because of B-Frames being used.", codec->name);
 			av_opt_set_int(context->priv_data, "weighted_pred", 0, AV_OPT_SEARCH_CHILDREN);
 		} else if (!util::is_tristate_default(wp)) {
 			av_opt_set_int(context->priv_data, "weighted_pred", wp, AV_OPT_SEARCH_CHILDREN);
@@ -700,7 +700,7 @@ void nvenc::log_options(obs_data_t*, const AVCodec* codec, AVCodecContext* conte
 {
 	using namespace ::ffmpeg;
 
-	LOG_INFO("[%s]   Nvidia NVENC:", codec->name);
+	DLOG_INFO("[%s]   Nvidia NVENC:", codec->name);
 	tools::print_av_option_string(context, "preset", "    Preset", [](int64_t v) {
 		preset      val   = static_cast<preset>(v);
 		std::string name  = "<Default>";
@@ -723,16 +723,16 @@ void nvenc::log_options(obs_data_t*, const AVCodec* codec, AVCodecContext* conte
 	if (strcmp(codec->name, "h264_nvenc") == 0)
 		tools::print_av_option_bool(context, "b_adapt", "      Adaptive B-Frames");
 
-	LOG_INFO("[%s]       Bitrate:", codec->name);
+	DLOG_INFO("[%s]       Bitrate:", codec->name);
 	tools::print_av_option_int(context, "b", "        Target", "bits/sec");
 	tools::print_av_option_int(context, "minrate", "        Minimum", "bits/sec");
 	tools::print_av_option_int(context, "maxrate", "        Maximum", "bits/sec");
 	tools::print_av_option_int(context, "bufsize", "        Buffer", "bits");
-	LOG_INFO("[%s]       Quality:", codec->name);
+	DLOG_INFO("[%s]       Quality:", codec->name);
 	tools::print_av_option_int(context, "cq", "        Target", "");
 	tools::print_av_option_int(context, "qmin", "        Minimum", "");
 	tools::print_av_option_int(context, "qmax", "        Maximum", "");
-	LOG_INFO("[%s]       Quantization Parameters:", codec->name);
+	DLOG_INFO("[%s]       Quantization Parameters:", codec->name);
 	tools::print_av_option_int(context, "init_qpI", "        I-Frame", "");
 	tools::print_av_option_int(context, "init_qpP", "        P-Frame", "");
 	tools::print_av_option_int(context, "init_qpB", "        B-Frame", "");
@@ -747,7 +747,7 @@ void nvenc::log_options(obs_data_t*, const AVCodec* codec, AVCodecContext* conte
 		return name;
 	});
 
-	LOG_INFO("[%s]     Adaptive Quantization:", codec->name);
+	DLOG_INFO("[%s]     Adaptive Quantization:", codec->name);
 	if (strcmp(codec->name, "h264_nvenc") == 0) {
 		tools::print_av_option_bool(context, "spatial-aq", "      Spatial AQ");
 		tools::print_av_option_int(context, "aq-strength", "        Strength", "");
@@ -758,7 +758,7 @@ void nvenc::log_options(obs_data_t*, const AVCodec* codec, AVCodecContext* conte
 		tools::print_av_option_bool(context, "temporal_aq", "      Temporal AQ");
 	}
 
-	LOG_INFO("[%s]     Other:", codec->name);
+	DLOG_INFO("[%s]     Other:", codec->name);
 	tools::print_av_option_bool(context, "zerolatency", "      Zero Latency");
 	tools::print_av_option_bool(context, "weighted_pred", "      Weighted Prediction");
 	tools::print_av_option_bool(context, "nonref_p", "      Non-reference P-Frames");

--- a/source/encoders/handlers/prores_aw_handler.cpp
+++ b/source/encoders/handlers/prores_aw_handler.cpp
@@ -103,7 +103,7 @@ void prores_aw_handler::update(obs_data_t* settings, const AVCodec*, AVCodecCont
 
 void prores_aw_handler::log_options(obs_data_t* settings, const AVCodec* codec, AVCodecContext* context)
 {
-	LOG_INFO("[%s]   Apple ProRes:", codec->name);
+	DLOG_INFO("[%s]   Apple ProRes:", codec->name);
 	::ffmpeg::tools::print_av_option_string(context, "profile", "    Profile", [&codec](int64_t v) {
 		int val = static_cast<int>(v);
 		for (auto ptr = codec->profiles; (ptr->profile != FF_PROFILE_UNKNOWN) && (ptr != nullptr); ptr++) {

--- a/source/ffmpeg/tools.cpp
+++ b/source/ffmpeg/tools.cpp
@@ -326,10 +326,10 @@ void ffmpeg::tools::print_av_option_bool(AVCodecContext* ctx_codec, void* ctx_op
 {
 	int64_t v = 0;
 	if (int err = av_opt_get_int(ctx_option, option, AV_OPT_SEARCH_CHILDREN, &v); err != 0) {
-		LOG_INFO("[%s] %s: <Error: %s>", ctx_codec->codec->name, text.c_str(),
+		DLOG_INFO("[%s] %s: <Error: %s>", ctx_codec->codec->name, text.c_str(),
 				 ffmpeg::tools::get_error_description(err));
 	} else {
-		LOG_INFO("[%s] %s: %s%s", ctx_codec->codec->name, text.c_str(),
+		DLOG_INFO("[%s] %s: %s%s", ctx_codec->codec->name, text.c_str(),
 				 (inverse ? v != 0 : v == 0) ? "Disabled" : "Enabled",
 				 av_opt_is_set_to_default_by_name(ctx_option, option, AV_OPT_SEARCH_CHILDREN) > 0 ? " <Default>" : "");
 	}
@@ -347,13 +347,13 @@ void ffmpeg::tools::print_av_option_int(AVCodecContext* ctx_codec, void* ctx_opt
 	bool    is_default = av_opt_is_set_to_default_by_name(ctx_option, option, AV_OPT_SEARCH_CHILDREN) > 0;
 	if (int err = av_opt_get_int(ctx_option, option, AV_OPT_SEARCH_CHILDREN, &v); err != 0) {
 		if (is_default) {
-			LOG_INFO("[%s] %s: <Default>", ctx_codec->codec->name, text.c_str());
+			DLOG_INFO("[%s] %s: <Default>", ctx_codec->codec->name, text.c_str());
 		} else {
-			LOG_INFO("[%s] %s: <Error: %s>", ctx_codec->codec->name, text.c_str(),
+			DLOG_INFO("[%s] %s: <Error: %s>", ctx_codec->codec->name, text.c_str(),
 					 ffmpeg::tools::get_error_description(err));
 		}
 	} else {
-		LOG_INFO("[%s] %s: %lld %s%s", ctx_codec->codec->name, text.c_str(), v, suffix.c_str(),
+		DLOG_INFO("[%s] %s: %lld %s%s", ctx_codec->codec->name, text.c_str(), v, suffix.c_str(),
 				 is_default ? " <Default>" : "");
 	}
 }
@@ -369,13 +369,13 @@ void ffmpeg::tools::print_av_option_string(AVCodecContext* ctx_codec, void* ctx_
 {
 	int64_t v = 0;
 	if (int err = av_opt_get_int(ctx_option, option, AV_OPT_SEARCH_CHILDREN, &v); err != 0) {
-		LOG_INFO("[%s] %s: <Error: %s>", ctx_codec->codec->name, text.c_str(),
+		DLOG_INFO("[%s] %s: <Error: %s>", ctx_codec->codec->name, text.c_str(),
 				 ffmpeg::tools::get_error_description(err));
 	} else {
 		std::string name = "<Unknown>";
 		if (decoder)
 			name = decoder(v);
-		LOG_INFO("[%s] %s: %s%s", ctx_codec->codec->name, text.c_str(), name.c_str(),
+		DLOG_INFO("[%s] %s: %s%s", ctx_codec->codec->name, text.c_str(), name.c_str(),
 				 av_opt_is_set_to_default_by_name(ctx_option, option, AV_OPT_SEARCH_CHILDREN) > 0 ? " <Default>" : "");
 	}
 }

--- a/source/filters/filter-blur.cpp
+++ b/source/filters/filter-blur.cpp
@@ -118,7 +118,7 @@ blur_instance::blur_instance(obs_data_t* settings, obs_source_t* self)
 			try {
 				_effect_mask = gs::effect::create(file);
 			} catch (std::runtime_error& ex) {
-				LOG_ERROR("<filter-blur> Loading _effect '%s' failed with error(s): %s", file, ex.what());
+				DLOG_ERROR("<filter-blur> Loading _effect '%s' failed with error(s): %s", file, ex.what());
 			}
 
 			bfree(file);
@@ -332,7 +332,7 @@ void blur_instance::video_tick(float)
 				_mask.image.texture  = std::make_shared<gs::texture>(_mask.image.path);
 				_mask.image.path_old = _mask.image.path;
 			} catch (...) {
-				LOG_ERROR("<filter-blur> Instance '%s' failed to load image '%s'.", obs_source_get_name(_self),
+				DLOG_ERROR("<filter-blur> Instance '%s' failed to load image '%s'.", obs_source_get_name(_self),
 						  _mask.image.path.c_str());
 			}
 		}
@@ -343,7 +343,7 @@ void blur_instance::video_tick(float)
 				_mask.source.is_scene = (obs_scene_from_source(_mask.source.source_texture->get_object()) != nullptr);
 				_mask.source.name_old = _mask.source.name;
 			} catch (...) {
-				LOG_ERROR("<filter-blur> Instance '%s' failed to grab source '%s'.", obs_source_get_name(_self),
+				DLOG_ERROR("<filter-blur> Instance '%s' failed to grab source '%s'.", obs_source_get_name(_self),
 						  _mask.source.name.c_str());
 			}
 		}
@@ -547,7 +547,7 @@ void blur_instance::video_render(gs_effect_t* effect)
 
 		gs_eparam_t* param = gs_effect_get_param_by_name(finalEffect, "image");
 		if (!param) {
-			LOG_ERROR("<filter-blur:%s> Failed to set image param.", obs_source_get_name(this->_self));
+			DLOG_ERROR("<filter-blur:%s> Failed to set image param.", obs_source_get_name(this->_self));
 			obs_source_skip_video_filter(_self);
 			return;
 		} else {
@@ -773,7 +773,7 @@ try {
 
 	return true;
 } catch (...) {
-	LOG_ERROR("Unexpected exception in modified_properties callback.");
+	DLOG_ERROR("Unexpected exception in modified_properties callback.");
 	return false;
 }
 

--- a/source/filters/filter-color-grade.cpp
+++ b/source/filters/filter-color-grade.cpp
@@ -88,7 +88,7 @@ color_grade_instance::color_grade_instance(obs_data_t* data, obs_source_t* self)
 				_effect = gs::effect::create(file);
 				bfree(file);
 			} catch (std::runtime_error& ex) {
-				LOG_ERROR("<filter-color-grade> Loading _effect '%s' failed with error(s): %s", file, ex.what());
+				DLOG_ERROR("<filter-color-grade> Loading _effect '%s' failed with error(s): %s", file, ex.what());
 				bfree(file);
 				throw ex;
 			}

--- a/source/filters/filter-dynamic-mask.cpp
+++ b/source/filters/filter-dynamic-mask.cpp
@@ -63,7 +63,7 @@ dynamic_mask_instance::dynamic_mask_instance(obs_data_t* settings, obs_source_t*
 		try {
 			_effect = gs::effect::create(file);
 		} catch (const std::exception& ex) {
-			LOG_ERROR("Loading channel mask effect failed with error(s):\n%s", ex.what());
+			DLOG_ERROR("Loading channel mask effect failed with error(s):\n%s", ex.what());
 		}
 		assert(_effect != nullptr);
 		bfree(file);
@@ -332,7 +332,7 @@ void dynamic_mask_instance::video_render(gs_effect_t* in_effect)
 		gs_effect_t* final_effect = in_effect ? in_effect : default_effect;
 		gs_eparam_t* param        = gs_effect_get_param_by_name(final_effect, "image");
 		if (!param) {
-			LOG_ERROR("<filter-dynamic-mask:%s> Failed to set image param.", obs_source_get_name(_self));
+			DLOG_ERROR("<filter-dynamic-mask:%s> Failed to set image param.", obs_source_get_name(_self));
 			obs_source_skip_video_filter(_self);
 			return;
 		} else {

--- a/source/filters/filter-nv-face-tracking.cpp
+++ b/source/filters/filter-nv-face-tracking.cpp
@@ -168,7 +168,7 @@ void face_tracking_instance::async_initialize(std::shared_ptr<void> ptr)
 		// Finally enable Temporal tracking if possible.
 		if (NvCV_Status res = _ar_library->set_uint32(_ar_feature.get(), NvAR_Parameter_Config(Temporal), 1);
 			res != NVCV_SUCCESS) {
-			LOG_WARNING("<%s> Unable to enable Temporal tracking mode.", obs_source_get_name(remote_work.get()));
+			DLOG_WARNING("<%s> Unable to enable Temporal tracking mode.", obs_source_get_name(remote_work.get()));
 		}
 
 		// Create Bounding Boxes Data
@@ -191,7 +191,7 @@ void face_tracking_instance::async_initialize(std::shared_ptr<void> ptr)
 
 		// And finally, load the feature (takes long).
 		if (NvCV_Status res = _ar_library->load(_ar_feature.get()); res != NVCV_SUCCESS) {
-			LOG_ERROR("<%s> Failed to load Face Tracking feature.", obs_source_get_name(_self));
+			DLOG_ERROR("<%s> Failed to load Face Tracking feature.", obs_source_get_name(_self));
 			_ar_loaded = false;
 			return;
 		} else {
@@ -299,7 +299,7 @@ void face_tracking_instance::async_track(std::shared_ptr<void> ptr)
 			if (NvCV_Status res = _ar_library->set_object(_ar_feature.get(), NvAR_Parameter_Input(Image),
 														  &_ar_image_bgr, sizeof(NvCVImage));
 				res != NVCV_SUCCESS) {
-				LOG_ERROR("<%s> Failed to update input image for tracking.", obs_source_get_name(_self));
+				DLOG_ERROR("<%s> Failed to update input image for tracking.", obs_source_get_name(_self));
 				return;
 			}
 
@@ -331,7 +331,7 @@ void face_tracking_instance::async_track(std::shared_ptr<void> ptr)
 
 			if (::nvidia::cuda::result res = _cuda->cuMemcpy2DAsync(&mc, _cuda_stream->get());
 				res != ::nvidia::cuda::result::SUCCESS) {
-				LOG_ERROR("<%s> Failed to prepare buffers for tracking.", obs_source_get_name(_self));
+				DLOG_ERROR("<%s> Failed to prepare buffers for tracking.", obs_source_get_name(_self));
 				return;
 			}
 		}
@@ -344,7 +344,7 @@ void face_tracking_instance::async_track(std::shared_ptr<void> ptr)
 					_ar_library->image_transfer(&_ar_image, &_ar_image_bgr, 1.0,
 												reinterpret_cast<CUstream_st*>(_cuda_stream->get()), &_ar_image_temp);
 				res != NVCV_SUCCESS) {
-				LOG_ERROR("<%s> Failed to convert from RGBX 32-bit to BGR 24-bit.", obs_source_get_name(_self));
+				DLOG_ERROR("<%s> Failed to convert from RGBX 32-bit to BGR 24-bit.", obs_source_get_name(_self));
 				return;
 			}
 
@@ -358,7 +358,7 @@ void face_tracking_instance::async_track(std::shared_ptr<void> ptr)
 			auto prof = _profile_ar_run->track();
 #endif
 			if (NvCV_Status res = _ar_library->run(_ar_feature.get()); res != NVCV_SUCCESS) {
-				LOG_ERROR("<%s> Failed to run tracking.", obs_source_get_name(_self));
+				DLOG_ERROR("<%s> Failed to run tracking.", obs_source_get_name(_self));
 				return;
 			}
 		}
@@ -583,7 +583,7 @@ void face_tracking_instance::video_render(gs_effect_t* effect)
 #ifdef ENABLE_PROFILING
 bool face_tracking_instance::button_profile(obs_properties_t* props, obs_property_t* property)
 {
-	LOG_INFO("%-22s: %-10s %-10s %-10s %-10s %-10s", "Task", "Total", "Count", "Average", "99.9%ile", "95.0%ile");
+	DLOG_INFO("%-22s: %-10s %-10s %-10s %-10s %-10s", "Task", "Total", "Count", "Average", "99.9%ile", "95.0%ile");
 
 	std::pair<std::string, std::shared_ptr<util::profiler>> profilers[]{
 		{"Capture", _profile_capture},   {"Reallocate", _profile_capture_realloc},
@@ -592,7 +592,7 @@ bool face_tracking_instance::button_profile(obs_properties_t* props, obs_propert
 		{"AR Run", _profile_ar_run},     {"AR Calculate", _profile_ar_calc},
 	};
 	for (auto& kv : profilers) {
-		LOG_INFO("  %-20s: %8lldµs %10lld %8lldµs %8lldµs %8lldµs", kv.first.c_str(),
+		DLOG_INFO("  %-20s: %8lldµs %10lld %8lldµs %8lldµs %8lldµs", kv.first.c_str(),
 				 std::chrono::duration_cast<std::chrono::microseconds>(kv.second->total_duration()).count(),
 				 kv.second->count(), static_cast<std::int64_t>(kv.second->average_duration() / 1000.0),
 				 std::chrono::duration_cast<std::chrono::microseconds>(kv.second->percentile(0.999)).count(),
@@ -722,7 +722,7 @@ void streamfx::filter::nvidia::face_tracking_factory::initialize()
 	try {
 		_filter_nvidia_face_tracking_factory_instance = std::make_shared<filter::nvidia::face_tracking_factory>();
 	} catch (const std::exception& ex) {
-		LOG_ERROR("<NVIDIA Face Tracking Filter> %s", ex.what());
+		DLOG_ERROR("<NVIDIA Face Tracking Filter> %s", ex.what());
 	}
 }
 

--- a/source/filters/filter-sdf-effects.cpp
+++ b/source/filters/filter-sdf-effects.cpp
@@ -99,13 +99,13 @@ sdf_effects_instance::sdf_effects_instance(obs_data_t* settings, obs_source_t* s
 		for (auto& kv : load_arr) {
 			char* path = obs_module_file(kv.first);
 			if (!path) {
-				LOG_ERROR(LOG_PREFIX "Unable to load _effect '%s' as file is missing or locked.", kv.first);
+				DLOG_ERROR(LOG_PREFIX "Unable to load _effect '%s' as file is missing or locked.", kv.first);
 				continue;
 			}
 			try {
 				kv.second = gs::effect::create(path);
 			} catch (const std::exception& ex) {
-				LOG_ERROR(LOG_PREFIX "Failed to load _effect '%s' (located at '%s') with error(s): %s", kv.first, path,
+				DLOG_ERROR(LOG_PREFIX "Failed to load _effect '%s' (located at '%s') with error(s): %s", kv.first, path,
 						  ex.what());
 			}
 			bfree(path);
@@ -589,10 +589,10 @@ try {
 	obs_property_set_visible(obs_properties_get(props, ST_SHADOW_INNER_ALPHA), v);
 	return true;
 } catch (const std::exception& ex) {
-	LOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
+	DLOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
 	return true;
 } catch (...) {
-	LOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
+	DLOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
 	return true;
 }
 
@@ -607,10 +607,10 @@ try {
 	obs_property_set_visible(obs_properties_get(props, ST_SHADOW_OUTER_ALPHA), v);
 	return true;
 } catch (const std::exception& ex) {
-	LOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
+	DLOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
 	return true;
 } catch (...) {
-	LOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
+	DLOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
 	return true;
 }
 
@@ -623,10 +623,10 @@ try {
 	obs_property_set_visible(obs_properties_get(props, ST_GLOW_INNER_SHARPNESS), v);
 	return true;
 } catch (const std::exception& ex) {
-	LOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
+	DLOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
 	return true;
 } catch (...) {
-	LOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
+	DLOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
 	return true;
 }
 
@@ -639,10 +639,10 @@ try {
 	obs_property_set_visible(obs_properties_get(props, ST_GLOW_OUTER_SHARPNESS), v);
 	return true;
 } catch (const std::exception& ex) {
-	LOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
+	DLOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
 	return true;
 } catch (...) {
-	LOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
+	DLOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
 	return true;
 }
 
@@ -656,10 +656,10 @@ try {
 	obs_property_set_visible(obs_properties_get(props, ST_OUTLINE_SHARPNESS), v);
 	return true;
 } catch (const std::exception& ex) {
-	LOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
+	DLOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
 	return true;
 } catch (...) {
-	LOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
+	DLOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
 	return true;
 }
 
@@ -670,10 +670,10 @@ try {
 	obs_property_set_visible(obs_properties_get(props, ST_SDF_THRESHOLD), show_advanced);
 	return true;
 } catch (const std::exception& ex) {
-	LOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
+	DLOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
 	return true;
 } catch (...) {
-	LOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
+	DLOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
 	return true;
 }
 

--- a/source/filters/filter-transform.cpp
+++ b/source/filters/filter-transform.cpp
@@ -488,10 +488,10 @@ try {
 
 	return true;
 } catch (const std::exception& ex) {
-	LOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
+	DLOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
 	return true;
 } catch (...) {
-	LOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
+	DLOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
 	return true;
 }
 

--- a/source/gfx/blur/gfx-blur-box-linear.cpp
+++ b/source/gfx/blur/gfx-blur-box-linear.cpp
@@ -43,7 +43,7 @@ gfx::blur::box_linear_data::box_linear_data()
 		_effect    = gs::effect::create(file);
 		bfree(file);
 	} catch (...) {
-		LOG_ERROR("<gfx::blur::box_linear> Failed to load _effect.");
+		DLOG_ERROR("<gfx::blur::box_linear> Failed to load _effect.");
 	}
 }
 

--- a/source/gfx/blur/gfx-blur-box.cpp
+++ b/source/gfx/blur/gfx-blur-box.cpp
@@ -43,7 +43,7 @@ gfx::blur::box_data::box_data()
 		_effect    = gs::effect::create(file);
 		bfree(file);
 	} catch (...) {
-		LOG_ERROR("<gfx::blur::box> Failed to load _effect.");
+		DLOG_ERROR("<gfx::blur::box> Failed to load _effect.");
 	}
 }
 

--- a/source/gfx/blur/gfx-blur-dual-filtering.cpp
+++ b/source/gfx/blur/gfx-blur-dual-filtering.cpp
@@ -59,7 +59,7 @@ gfx::blur::dual_filtering_data::dual_filtering_data()
 		_effect    = gs::effect::create(file);
 		bfree(file);
 	} catch (...) {
-		LOG_ERROR("<gfx::blur::box_linear> Failed to load _effect.");
+		DLOG_ERROR("<gfx::blur::box_linear> Failed to load _effect.");
 	}
 }
 

--- a/source/gfx/shader/gfx-shader.cpp
+++ b/source/gfx/shader/gfx-shader.cpp
@@ -74,7 +74,7 @@ try {
 
 	return false;
 } catch (const std::exception& ex) {
-	LOG_ERROR("Loading shader '%s' failed with error: %s", file.c_str(), ex.what());
+	DLOG_ERROR("Loading shader '%s' failed with error: %s", file.c_str(), ex.what());
 	return false;
 }
 
@@ -174,7 +174,7 @@ try {
 
 	return true;
 } catch (const std::exception& ex) {
-	LOG_ERROR("Loading shader '%s' failed with error: %s", file.c_str(), ex.what());
+	DLOG_ERROR("Loading shader '%s' failed with error: %s", file.c_str(), ex.what());
 	return false;
 } catch (...) {
 	return false;

--- a/source/obs/obs-encoder-factory.hpp
+++ b/source/obs/obs-encoder-factory.hpp
@@ -96,10 +96,10 @@ namespace obs {
 				return reinterpret_cast<factory_t*>(type_data)->get_name();
 			return nullptr;
 		} catch (const std::exception& ex) {
-			LOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
+			DLOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
 			return nullptr;
 		} catch (...) {
-			LOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
+			DLOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
 			return nullptr;
 		}
 
@@ -116,10 +116,10 @@ namespace obs {
 				}
 			}
 		} catch (const std::exception& ex) {
-			LOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
+			DLOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
 			return nullptr;
 		} catch (...) {
-			LOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
+			DLOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
 			return nullptr;
 		}
 
@@ -128,9 +128,9 @@ namespace obs {
 			if (type_data)
 				reinterpret_cast<factory_t*>(type_data)->get_defaults2(settings);
 		} catch (const std::exception& ex) {
-			LOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
+			DLOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
 		} catch (...) {
-			LOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
+			DLOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
 		}
 
 		static obs_properties_t* _get_properties2(void* data, void* type_data) noexcept
@@ -139,10 +139,10 @@ namespace obs {
 				return reinterpret_cast<factory_t*>(type_data)->get_properties2(reinterpret_cast<instance_t*>(data));
 			return nullptr;
 		} catch (const std::exception& ex) {
-			LOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
+			DLOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
 			return nullptr;
 		} catch (...) {
-			LOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
+			DLOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
 			return nullptr;
 		}
 
@@ -152,9 +152,9 @@ namespace obs {
 			if (data)
 				delete reinterpret_cast<instance_t*>(data);
 		} catch (const std::exception& ex) {
-			LOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
+			DLOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
 		} catch (...) {
-			LOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
+			DLOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
 		}
 
 		static bool _update(void* data, obs_data_t* settings) noexcept
@@ -169,10 +169,10 @@ namespace obs {
 			}
 			return false;
 		} catch (const std::exception& ex) {
-			LOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
+			DLOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
 			return false;
 		} catch (...) {
-			LOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
+			DLOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
 			return false;
 		}
 
@@ -183,10 +183,10 @@ namespace obs {
 				return reinterpret_cast<instance_t*>(data)->encode(frame, packet, received_packet);
 			return false;
 		} catch (const std::exception& ex) {
-			LOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
+			DLOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
 			return false;
 		} catch (...) {
-			LOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
+			DLOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
 			return false;
 		}
 
@@ -198,10 +198,10 @@ namespace obs {
 																		 received_packet);
 			return false;
 		} catch (const std::exception& ex) {
-			LOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
+			DLOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
 			return false;
 		} catch (...) {
-			LOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
+			DLOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
 			return false;
 		}
 
@@ -211,10 +211,10 @@ namespace obs {
 				return reinterpret_cast<instance_t*>(data)->get_frame_size();
 			return 0;
 		} catch (const std::exception& ex) {
-			LOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
+			DLOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
 			return 0;
 		} catch (...) {
-			LOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
+			DLOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
 			return 0;
 		}
 
@@ -224,10 +224,10 @@ namespace obs {
 				return reinterpret_cast<instance_t*>(data)->get_extra_data(extra_data, size);
 			return false;
 		} catch (const std::exception& ex) {
-			LOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
+			DLOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
 			return false;
 		} catch (...) {
-			LOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
+			DLOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
 			return false;
 		}
 
@@ -237,10 +237,10 @@ namespace obs {
 				return reinterpret_cast<instance_t*>(data)->get_sei_data(sei_data, size);
 			return false;
 		} catch (const std::exception& ex) {
-			LOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
+			DLOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
 			return false;
 		} catch (...) {
-			LOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
+			DLOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
 			return false;
 		}
 
@@ -249,9 +249,9 @@ namespace obs {
 			if (data)
 				reinterpret_cast<instance_t*>(data)->get_audio_info(info);
 		} catch (const std::exception& ex) {
-			LOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
+			DLOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
 		} catch (...) {
-			LOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
+			DLOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
 		}
 
 		static void _get_video_info(void* data, struct video_scale_info* info) noexcept
@@ -259,9 +259,9 @@ namespace obs {
 			if (data)
 				reinterpret_cast<instance_t*>(data)->get_video_info(info);
 		} catch (const std::exception& ex) {
-			LOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
+			DLOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
 		} catch (...) {
-			LOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
+			DLOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
 		}
 
 		public:

--- a/source/obs/obs-source-factory.hpp
+++ b/source/obs/obs-source-factory.hpp
@@ -189,10 +189,10 @@ namespace obs {
 				return reinterpret_cast<_factory*>(type_data)->get_name();
 			return nullptr;
 		} catch (const std::exception& ex) {
-			LOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
+			DLOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
 			return nullptr;
 		} catch (...) {
-			LOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
+			DLOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
 			return nullptr;
 		}
 
@@ -200,10 +200,10 @@ namespace obs {
 		try {
 			return reinterpret_cast<_factory*>(obs_source_get_type_data(source))->create(settings, source);
 		} catch (const std::exception& ex) {
-			LOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
+			DLOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
 			return nullptr;
 		} catch (...) {
-			LOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
+			DLOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
 			return nullptr;
 		}
 
@@ -212,9 +212,9 @@ namespace obs {
 			if (type_data)
 				reinterpret_cast<_factory*>(type_data)->get_defaults2(settings);
 		} catch (const std::exception& ex) {
-			LOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
+			DLOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
 		} catch (...) {
-			LOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
+			DLOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
 		}
 
 		static obs_properties_t* _get_properties2(void* data, void* type_data) noexcept
@@ -223,10 +223,10 @@ namespace obs {
 				return reinterpret_cast<_factory*>(type_data)->get_properties2(reinterpret_cast<_instance*>(data));
 			return nullptr;
 		} catch (const std::exception& ex) {
-			LOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
+			DLOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
 			return nullptr;
 		} catch (...) {
-			LOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
+			DLOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
 			return nullptr;
 		}
 
@@ -236,9 +236,9 @@ namespace obs {
 			if (data)
 				delete reinterpret_cast<_instance*>(data);
 		} catch (const std::exception& ex) {
-			LOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
+			DLOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
 		} catch (...) {
-			LOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
+			DLOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
 		}
 
 		static std::uint32_t _get_width(void* data) noexcept
@@ -247,10 +247,10 @@ namespace obs {
 				return reinterpret_cast<_instance*>(data)->get_width();
 			return 0;
 		} catch (const std::exception& ex) {
-			LOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
+			DLOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
 			return 0;
 		} catch (...) {
-			LOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
+			DLOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
 			return 0;
 		}
 
@@ -260,10 +260,10 @@ namespace obs {
 				return reinterpret_cast<_instance*>(data)->get_height();
 			return 0;
 		} catch (const std::exception& ex) {
-			LOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
+			DLOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
 			return 0;
 		} catch (...) {
-			LOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
+			DLOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
 			return 0;
 		}
 
@@ -272,9 +272,9 @@ namespace obs {
 			if (data)
 				reinterpret_cast<_instance*>(data)->activate();
 		} catch (const std::exception& ex) {
-			LOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
+			DLOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
 		} catch (...) {
-			LOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
+			DLOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
 		}
 
 		static void _deactivate(void* data) noexcept
@@ -282,9 +282,9 @@ namespace obs {
 			if (data)
 				reinterpret_cast<_instance*>(data)->deactivate();
 		} catch (const std::exception& ex) {
-			LOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
+			DLOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
 		} catch (...) {
-			LOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
+			DLOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
 		}
 
 		static void _show(void* data) noexcept
@@ -292,9 +292,9 @@ namespace obs {
 			if (data)
 				reinterpret_cast<_instance*>(data)->show();
 		} catch (const std::exception& ex) {
-			LOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
+			DLOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
 		} catch (...) {
-			LOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
+			DLOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
 		}
 
 		static void _hide(void* data) noexcept
@@ -302,9 +302,9 @@ namespace obs {
 			if (data)
 				reinterpret_cast<_instance*>(data)->hide();
 		} catch (const std::exception& ex) {
-			LOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
+			DLOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
 		} catch (...) {
-			LOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
+			DLOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
 		}
 
 		static void _video_tick(void* data, float seconds) noexcept
@@ -312,9 +312,9 @@ namespace obs {
 			if (data)
 				reinterpret_cast<_instance*>(data)->video_tick(seconds);
 		} catch (const std::exception& ex) {
-			LOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
+			DLOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
 		} catch (...) {
-			LOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
+			DLOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
 		}
 
 		static void _video_render(void* data, gs_effect_t* effect) noexcept
@@ -322,9 +322,9 @@ namespace obs {
 			if (data)
 				reinterpret_cast<_instance*>(data)->video_render(effect);
 		} catch (const std::exception& ex) {
-			LOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
+			DLOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
 		} catch (...) {
-			LOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
+			DLOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
 		}
 
 		static struct obs_source_frame* _filter_video(void* data, struct obs_source_frame* frame) noexcept
@@ -333,10 +333,10 @@ namespace obs {
 				return reinterpret_cast<_instance*>(data)->filter_video(frame);
 			return frame;
 		} catch (const std::exception& ex) {
-			LOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
+			DLOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
 			return frame;
 		} catch (...) {
-			LOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
+			DLOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
 			return frame;
 		}
 
@@ -346,10 +346,10 @@ namespace obs {
 				return reinterpret_cast<_instance*>(data)->filter_audio(frame);
 			return frame;
 		} catch (const std::exception& ex) {
-			LOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
+			DLOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
 			return frame;
 		} catch (...) {
-			LOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
+			DLOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
 			return frame;
 		}
 
@@ -358,9 +358,9 @@ namespace obs {
 			if (data)
 				reinterpret_cast<_instance*>(data)->enum_active_sources(enum_callback, param);
 		} catch (const std::exception& ex) {
-			LOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
+			DLOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
 		} catch (...) {
-			LOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
+			DLOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
 		}
 
 		static void _load(void* data, obs_data_t* settings) noexcept
@@ -374,9 +374,9 @@ namespace obs {
 				priv->load(settings);
 			}
 		} catch (const std::exception& ex) {
-			LOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
+			DLOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
 		} catch (...) {
-			LOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
+			DLOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
 		}
 
 		static void _update(void* data, obs_data_t* settings) noexcept
@@ -384,9 +384,9 @@ namespace obs {
 			if (data)
 				reinterpret_cast<_instance*>(data)->update(settings);
 		} catch (const std::exception& ex) {
-			LOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
+			DLOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
 		} catch (...) {
-			LOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
+			DLOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
 		}
 
 		static void _save(void* data, obs_data_t* settings) noexcept
@@ -397,9 +397,9 @@ namespace obs {
 				obs_data_set_string(settings, S_COMMIT, STREAMFX_COMMIT);
 			}
 		} catch (const std::exception& ex) {
-			LOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
+			DLOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
 		} catch (...) {
-			LOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
+			DLOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
 		}
 
 		static void _mouse_click(void* data, const struct obs_mouse_event* event, int32_t type, bool mouse_up,
@@ -408,9 +408,9 @@ namespace obs {
 			if (data)
 				reinterpret_cast<_instance*>(data)->mouse_click(event, type, mouse_up, click_count);
 		} catch (const std::exception& ex) {
-			LOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
+			DLOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
 		} catch (...) {
-			LOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
+			DLOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
 		}
 
 		static void _mouse_move(void* data, const struct obs_mouse_event* event, bool mouse_leave) noexcept
@@ -418,9 +418,9 @@ namespace obs {
 			if (data)
 				reinterpret_cast<_instance*>(data)->mouse_move(event, mouse_leave);
 		} catch (const std::exception& ex) {
-			LOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
+			DLOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
 		} catch (...) {
-			LOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
+			DLOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
 		}
 
 		static void _mouse_wheel(void* data, const struct obs_mouse_event* event, int x_delta, int y_delta) noexcept
@@ -428,9 +428,9 @@ namespace obs {
 			if (data)
 				reinterpret_cast<_instance*>(data)->mouse_wheel(event, x_delta, y_delta);
 		} catch (const std::exception& ex) {
-			LOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
+			DLOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
 		} catch (...) {
-			LOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
+			DLOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
 		}
 
 		static void _focus(void* data, bool focus) noexcept
@@ -438,9 +438,9 @@ namespace obs {
 			if (data)
 				reinterpret_cast<_instance*>(data)->focus(focus);
 		} catch (const std::exception& ex) {
-			LOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
+			DLOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
 		} catch (...) {
-			LOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
+			DLOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
 		}
 
 		static void _key_click(void* data, const struct obs_key_event* event, bool key_up) noexcept
@@ -448,9 +448,9 @@ namespace obs {
 			if (data)
 				reinterpret_cast<_instance*>(data)->key_click(event, key_up);
 		} catch (const std::exception& ex) {
-			LOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
+			DLOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
 		} catch (...) {
-			LOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
+			DLOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
 		}
 
 		static void _filter_remove(void* data, obs_source_t* source) noexcept
@@ -458,9 +458,9 @@ namespace obs {
 			if (data)
 				reinterpret_cast<_instance*>(data)->filter_remove(source);
 		} catch (const std::exception& ex) {
-			LOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
+			DLOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
 		} catch (...) {
-			LOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
+			DLOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
 		}
 
 		static bool _audio_render(void* data, uint64_t* ts_out, struct obs_source_audio_mix* audio_output,
@@ -471,10 +471,10 @@ namespace obs {
 																		sample_rate);
 			return false;
 		} catch (const std::exception& ex) {
-			LOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
+			DLOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
 			return false;
 		} catch (...) {
-			LOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
+			DLOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
 			return false;
 		}
 
@@ -483,9 +483,9 @@ namespace obs {
 			if (data)
 				reinterpret_cast<_instance*>(data)->enum_all_sources(enum_callback, param);
 		} catch (const std::exception& ex) {
-			LOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
+			DLOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
 		} catch (...) {
-			LOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
+			DLOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
 		}
 
 		static void _transition_start(void* data) noexcept
@@ -493,9 +493,9 @@ namespace obs {
 			if (data)
 				reinterpret_cast<_instance*>(data)->transition_start();
 		} catch (const std::exception& ex) {
-			LOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
+			DLOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
 		} catch (...) {
-			LOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
+			DLOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
 		}
 
 		static void _transition_stop(void* data) noexcept
@@ -503,9 +503,9 @@ namespace obs {
 			if (data)
 				reinterpret_cast<_instance*>(data)->transition_stop();
 		} catch (const std::exception& ex) {
-			LOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
+			DLOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
 		} catch (...) {
-			LOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
+			DLOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
 		}
 
 		static bool _audio_mix(void* data, uint64_t* ts_out, struct audio_output_data* audio_output,
@@ -515,10 +515,10 @@ namespace obs {
 				return reinterpret_cast<_instance*>(data)->audio_mix(ts_out, audio_output, channels, sample_rate);
 			return false;
 		} catch (const std::exception& ex) {
-			LOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
+			DLOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
 			return false;
 		} catch (...) {
-			LOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
+			DLOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
 			return false;
 		}
 

--- a/source/obs/obs-source-tracker.cpp
+++ b/source/obs/obs-source-tracker.cpp
@@ -47,7 +47,7 @@ try {
 
 	self->_source_map.insert({std::string(name), weak});
 } catch (...) {
-	LOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
+	DLOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
 }
 
 void obs::source_tracker::source_destroy_handler(void* ptr, calldata_t* data) noexcept
@@ -75,7 +75,7 @@ try {
 	obs_weak_source_release(found->second);
 	self->_source_map.erase(found);
 } catch (...) {
-	LOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
+	DLOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
 }
 
 void obs::source_tracker::source_rename_handler(void* ptr, calldata_t* data) noexcept
@@ -109,7 +109,7 @@ try {
 	self->_source_map.insert({new_name, found->second});
 	self->_source_map.erase(found);
 } catch (...) {
-	LOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
+	DLOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
 }
 
 void obs::source_tracker::initialize()

--- a/source/obs/obs-source.cpp
+++ b/source/obs/obs-source.cpp
@@ -39,9 +39,9 @@ try {
 	}
 	self->events.destroy(self);
 } catch (const std::exception& ex) {
-	LOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
+	DLOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
 } catch (...) {
-	LOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
+	DLOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
 }
 
 void obs::deprecated_source::handle_remove(void* p, calldata_t*) noexcept
@@ -52,9 +52,9 @@ try {
 	}
 	self->events.remove(self);
 } catch (const std::exception& ex) {
-	LOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
+	DLOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
 } catch (...) {
-	LOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
+	DLOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
 }
 
 void obs::deprecated_source::handle_save(void* p, calldata_t*) noexcept
@@ -65,9 +65,9 @@ try {
 	}
 	self->events.save(self);
 } catch (const std::exception& ex) {
-	LOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
+	DLOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
 } catch (...) {
-	LOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
+	DLOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
 }
 
 void obs::deprecated_source::handle_load(void* p, calldata_t*) noexcept
@@ -78,9 +78,9 @@ try {
 	}
 	self->events.load(self);
 } catch (const std::exception& ex) {
-	LOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
+	DLOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
 } catch (...) {
-	LOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
+	DLOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
 }
 
 void obs::deprecated_source::handle_activate(void* p, calldata_t*) noexcept
@@ -91,9 +91,9 @@ try {
 	}
 	self->events.activate(self);
 } catch (const std::exception& ex) {
-	LOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
+	DLOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
 } catch (...) {
-	LOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
+	DLOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
 }
 
 void obs::deprecated_source::handle_deactivate(void* p, calldata_t*) noexcept
@@ -104,9 +104,9 @@ try {
 	}
 	self->events.deactivate(self);
 } catch (const std::exception& ex) {
-	LOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
+	DLOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
 } catch (...) {
-	LOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
+	DLOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
 }
 
 void obs::deprecated_source::handle_show(void* p, calldata_t*) noexcept
@@ -117,9 +117,9 @@ try {
 	}
 	self->events.show(self);
 } catch (const std::exception& ex) {
-	LOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
+	DLOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
 } catch (...) {
-	LOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
+	DLOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
 }
 
 void obs::deprecated_source::handle_hide(void* p, calldata_t*) noexcept
@@ -130,9 +130,9 @@ try {
 	}
 	self->events.hide(self);
 } catch (const std::exception& ex) {
-	LOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
+	DLOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
 } catch (...) {
-	LOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
+	DLOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
 }
 
 void obs::deprecated_source::handle_enable(void* p, calldata_t* calldata) noexcept
@@ -149,9 +149,9 @@ try {
 
 	self->events.enable(self, enabled);
 } catch (const std::exception& ex) {
-	LOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
+	DLOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
 } catch (...) {
-	LOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
+	DLOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
 }
 
 void obs::deprecated_source::handle_push_to_mute_changed(void* p, calldata_t* calldata) noexcept
@@ -168,9 +168,9 @@ try {
 
 	self->events.push_to_mute_changed(self, enabled);
 } catch (const std::exception& ex) {
-	LOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
+	DLOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
 } catch (...) {
-	LOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
+	DLOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
 }
 
 void obs::deprecated_source::handle_push_to_mute_delay(void* p, calldata_t* calldata) noexcept
@@ -187,9 +187,9 @@ try {
 
 	self->events.push_to_mute_delay(self, delay);
 } catch (const std::exception& ex) {
-	LOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
+	DLOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
 } catch (...) {
-	LOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
+	DLOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
 }
 
 void obs::deprecated_source::handle_push_to_talk_changed(void* p, calldata_t* calldata) noexcept
@@ -206,9 +206,9 @@ try {
 
 	self->events.push_to_talk_changed(self, enabled);
 } catch (const std::exception& ex) {
-	LOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
+	DLOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
 } catch (...) {
-	LOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
+	DLOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
 }
 
 void obs::deprecated_source::handle_push_to_talk_delay(void* p, calldata_t* calldata) noexcept
@@ -225,9 +225,9 @@ try {
 
 	self->events.push_to_talk_delay(self, delay);
 } catch (const std::exception& ex) {
-	LOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
+	DLOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
 } catch (...) {
-	LOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
+	DLOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
 }
 
 void obs::deprecated_source::handle_rename(void* p, calldata_t* calldata) noexcept
@@ -249,9 +249,9 @@ try {
 
 	self->events.rename(self, std::string(new_name ? new_name : ""), std::string(prev_name ? prev_name : ""));
 } catch (const std::exception& ex) {
-	LOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
+	DLOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
 } catch (...) {
-	LOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
+	DLOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
 }
 
 void obs::deprecated_source::handle_update_properties(void* p, calldata_t*) noexcept
@@ -262,9 +262,9 @@ try {
 	}
 	self->events.update_properties(self);
 } catch (const std::exception& ex) {
-	LOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
+	DLOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
 } catch (...) {
-	LOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
+	DLOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
 }
 
 void obs::deprecated_source::handle_update_flags(void* p, calldata_t* calldata) noexcept
@@ -281,9 +281,9 @@ try {
 
 	self->events.update_flags(self, flags);
 } catch (const std::exception& ex) {
-	LOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
+	DLOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
 } catch (...) {
-	LOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
+	DLOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
 }
 
 void obs::deprecated_source::handle_mute(void* p, calldata_t* calldata) noexcept
@@ -300,9 +300,9 @@ try {
 
 	self->events.mute(self, muted);
 } catch (const std::exception& ex) {
-	LOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
+	DLOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
 } catch (...) {
-	LOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
+	DLOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
 }
 
 void obs::deprecated_source::handle_volume(void* p, calldata_t* calldata) noexcept
@@ -321,9 +321,9 @@ try {
 
 	calldata_set_float(calldata, "volume", volume);
 } catch (const std::exception& ex) {
-	LOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
+	DLOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
 } catch (...) {
-	LOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
+	DLOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
 }
 
 void obs::deprecated_source::handle_audio_sync(void* p, calldata_t* calldata) noexcept
@@ -342,9 +342,9 @@ try {
 
 	calldata_set_int(calldata, "offset", mixers);
 } catch (const std::exception& ex) {
-	LOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
+	DLOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
 } catch (...) {
-	LOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
+	DLOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
 }
 
 void obs::deprecated_source::handle_audio_mixers(void* p, calldata_t* calldata) noexcept
@@ -363,9 +363,9 @@ try {
 
 	calldata_set_int(calldata, "mixers", mixers);
 } catch (const std::exception& ex) {
-	LOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
+	DLOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
 } catch (...) {
-	LOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
+	DLOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
 }
 
 void obs::deprecated_source::handle_audio_data(void* p, obs_source_t*, const audio_data* audio, bool muted) noexcept
@@ -377,9 +377,9 @@ try {
 
 	self->events.audio(self, audio, muted);
 } catch (const std::exception& ex) {
-	LOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
+	DLOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
 } catch (...) {
-	LOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
+	DLOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
 }
 
 void obs::deprecated_source::handle_filter_add(void* p, calldata_t* calldata) noexcept
@@ -396,9 +396,9 @@ try {
 
 	self->events.filter_add(self, filter);
 } catch (const std::exception& ex) {
-	LOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
+	DLOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
 } catch (...) {
-	LOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
+	DLOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
 }
 
 void obs::deprecated_source::handle_filter_remove(void* p, calldata_t* calldata) noexcept
@@ -415,9 +415,9 @@ try {
 
 	self->events.filter_remove(self, filter);
 } catch (const std::exception& ex) {
-	LOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
+	DLOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
 } catch (...) {
-	LOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
+	DLOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
 }
 
 void obs::deprecated_source::handle_reorder_filters(void* p, calldata_t*) noexcept
@@ -428,9 +428,9 @@ try {
 	}
 	self->events.reorder_filters(self);
 } catch (const std::exception& ex) {
-	LOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
+	DLOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
 } catch (...) {
-	LOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
+	DLOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
 }
 
 void obs::deprecated_source::handle_transition_start(void* p, calldata_t*) noexcept
@@ -441,9 +441,9 @@ try {
 	}
 	self->events.transition_start(self);
 } catch (const std::exception& ex) {
-	LOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
+	DLOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
 } catch (...) {
-	LOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
+	DLOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
 }
 
 void obs::deprecated_source::handle_transition_video_stop(void* p, calldata_t*) noexcept
@@ -454,9 +454,9 @@ try {
 	}
 	self->events.transition_video_stop(self);
 } catch (const std::exception& ex) {
-	LOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
+	DLOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
 } catch (...) {
-	LOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
+	DLOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
 }
 
 void obs::deprecated_source::handle_transition_stop(void* p, calldata_t*) noexcept
@@ -467,9 +467,9 @@ try {
 	}
 	self->events.transition_stop(self);
 } catch (const std::exception& ex) {
-	LOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
+	DLOG_ERROR("Unexpected exception in function '%s': %s.", __FUNCTION_NAME__, ex.what());
 } catch (...) {
-	LOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
+	DLOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
 }
 
 obs::deprecated_source::~deprecated_source()

--- a/source/obs/obs-tools.cpp
+++ b/source/obs/obs-tools.cpp
@@ -35,7 +35,7 @@ try {
 	scs_searchdata& sd = reinterpret_cast<scs_searchdata&>(*reinterpret_cast<scs_searchdata*>(searchdata));
 	scs_contains(sd, child);
 } catch (...) {
-	LOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
+	DLOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
 }
 
 static bool scs_enum_items_cb(obs_scene_t*, obs_sceneitem_t* item, void* searchdata) noexcept
@@ -44,7 +44,7 @@ try {
 	obs_source_t*   source = obs_sceneitem_get_source(item);
 	return scs_contains(sd, source);
 } catch (...) {
-	LOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
+	DLOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
 	return false;
 }
 

--- a/source/plugin.cpp
+++ b/source/plugin.cpp
@@ -72,7 +72,7 @@ static std::shared_ptr<gs::vertex_buffer> _gs_fstri_vb;
 
 MODULE_EXPORT bool obs_module_load(void)
 try {
-	LOG_INFO("Loading Version %s", STREAMFX_VERSION_STRING);
+	DLOG_INFO("Loading Version %s", STREAMFX_VERSION_STRING);
 
 	// Initialize global configuration.
 	streamfx::configuration::initialize();
@@ -165,16 +165,16 @@ try {
 	streamfx::ui::handler::initialize();
 #endif
 
-	LOG_INFO("Loaded Version %s", STREAMFX_VERSION_STRING);
+	DLOG_INFO("Loaded Version %s", STREAMFX_VERSION_STRING);
 	return true;
 } catch (...) {
-	LOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
+	DLOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
 	return false;
 }
 
 MODULE_EXPORT void obs_module_unload(void)
 try {
-	LOG_INFO("Unloading Version %s", STREAMFX_VERSION_STRING);
+	DLOG_INFO("Unloading Version %s", STREAMFX_VERSION_STRING);
 
 	// Frontend
 #ifdef ENABLE_FRONTEND
@@ -251,9 +251,9 @@ try {
 	// Finalize Configuration
 	streamfx::configuration::finalize();
 
-	LOG_INFO("Unloaded Version %s", STREAMFX_VERSION_STRING);
+	DLOG_INFO("Unloaded Version %s", STREAMFX_VERSION_STRING);
 } catch (...) {
-	LOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
+	DLOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
 }
 
 std::shared_ptr<util::threadpool> streamfx::threadpool()

--- a/source/ui/ui.cpp
+++ b/source/ui/ui.cpp
@@ -44,7 +44,7 @@ constexpr std::string_view _cfg_have_shown_about = "UI.HaveShownAboutStreamFX";
 constexpr std::string_view _url_report_issue = "https://github.com/Xaymar/obs-StreamFX/issues/new?template=issue.md";
 constexpr std::string_view _url_request_help = "https://github.com/Xaymar/obs-StreamFX/issues/new?template=help.md";
 constexpr std::string_view _url_website      = "https://streamfx.xaymar.com";
-constexpr std::string_view _url_discord      = "https://discordapp.com/invite/DaeJg7M";
+constexpr std::string_view _url_discord      = "https://discord.gg/rjkxERs";
 constexpr std::string_view _url_github       = "https://github.com/Xaymar/obs-StreamFX";
 
 inline void qt_init_resource()


### PR DESCRIPTION
<!-- Hi, thank you for taking the time to submit a pull request. -->
<!-- Please make sure that you fill this out in it's entirety. -->

### Description
Prevents potential macro confusion in other compilers by ensuring that the name of the log macro is unique.
<!-- Describe your changes in as much detail as possible. -->
<!-- But please exclude your personal history from this. Only describe the changes -->

### Related Issues
<!-- - #0000 Name of Issue -->
<!-- - #0001 Name of Issue -->
