### PR TITLE
Fix memory leak caused by obs::source_tracker

### DIFF
--- a/source/obs/obs-source-tracker.hpp
+++ b/source/obs/obs-source-tracker.hpp
@@ -21,10 +21,12 @@
 #include "common.hpp"
 #include <functional>
 #include <map>
+#include <mutex>
 
 namespace obs {
 	class source_tracker {
-		std::map<std::string, obs_weak_source_t*> _source_map;
+		std::map<std::string, std::shared_ptr<obs_weak_source_t>> _sources;
+		std::mutex                                                _lock;
 
 		static void source_create_handler(void* ptr, calldata_t* data) noexcept;
 		static void source_destroy_handler(void* ptr, calldata_t* data) noexcept;


### PR DESCRIPTION
<!-- Hi, thank you for taking the time to submit a pull request. -->
<!-- Please make sure that you fill this out in it's entirety. -->

### Description
Fixes a memory leak caused by not releasing the weak pointer generated when creating sources.
<!-- Describe your changes in as much detail as possible. -->
<!-- But please exclude your personal history from this. Only describe the changes -->

### Related Issues
<!-- - #0000 Name of Issue -->
<!-- - #0001 Name of Issue -->
