### PR TITLE
Fix memory leak caused by configuration object and UI

### DIFF
--- a/source/configuration.cpp
+++ b/source/configuration.cpp
@@ -44,18 +44,18 @@ streamfx::configuration::~configuration()
 streamfx::configuration::configuration() : _data(), _config_path()
 {
 	{ // Retrieve global configuration path.
-		const char* path = obs_module_config_path("config.json");
+		char* path = obs_module_config_path("config.json");
 		_config_path     = path;
+		bfree(path);
 	}
 
 	try {
 		if (!std::filesystem::exists(_config_path) || !std::filesystem::is_regular_file(_config_path)) {
-			throw std::exception();
+			throw std::runtime_error("Configuration does not exist.");
 		} else {
-			obs_data_t* data =
-				obs_data_create_from_json_file_safe(_config_path.string().c_str(), path_backup_ext.data());
+			obs_data_t* data = obs_data_create_from_json_file_safe(_config_path.string().c_str(), path_backup_ext.data());
 			if (!data) {
-				throw std::exception();
+				throw std::runtime_error("Failed to load configuration from disk.");
 			} else {
 				_data = std::shared_ptr<obs_data_t>(data, obs::obs_data_deleter);
 			}

--- a/source/ui/ui.cpp
+++ b/source/ui/ui.cpp
@@ -59,13 +59,15 @@ inline void qt_cleanup_resource()
 
 bool streamfx::ui::handler::have_shown_about_streamfx(bool shown)
 {
+	auto config = streamfx::configuration::instance();
+	auto data   = config->get();
 	if (shown) {
-		obs_data_set_bool(streamfx::configuration::instance()->get().get(), _cfg_have_shown_about.data(), true);
+		obs_data_set_bool(data.get(), _cfg_have_shown_about.data(), true);
 	}
-	if (streamfx::configuration::instance()->is_different_version()) {
+	if (config->is_different_version()) {
 		return false;
 	} else {
-		return obs_data_get_bool(streamfx::configuration::instance()->get().get(), _cfg_have_shown_about.data());
+		return obs_data_get_bool(data.get(), _cfg_have_shown_about.data());
 	}
 }
 


### PR DESCRIPTION
<!-- Hi, thank you for taking the time to submit a pull request. -->
<!-- Please make sure that you fill this out in it's entirety. -->

### Description
Fixes a memory leak caused by the configuration and adds exception messages for debugging purposes. The leak is kind of weird, but may be completely explainable by the standard. 

In ui/ui.cpp a copy of the shared_ptr is created, which is then used to get a copy of the internal shared_ptr, which is then used to get the actual obs_data_t. This series of steps somehow increases the reference count to both shared_ptrs permanently, and does not decrement it again. Since they are now always above 0 references, they end up leaking past the module lifetime.

### Related Issues
<!-- - #0000 Name of Issue -->
<!-- - #0001 Name of Issue -->
