### PR TITLE
util/threadpool: Don't hold work endlessly after processing it

### DIFF
--- a/source/util/util-threadpool.cpp
+++ b/source/util/util-threadpool.cpp
@@ -112,6 +112,9 @@ void util::threadpool::work()
 							 reinterpret_cast<ptrdiff_t>(local_work->_data.get()));
 			}
 		}
+
+		// Remove our reference to the work unit.
+		local_work.reset();
 	}
 
 	_worker_idx.fetch_sub(1);


### PR DESCRIPTION
<!-- Hi, thank you for taking the time to submit a pull request. -->
<!-- Please make sure that you fill this out in it's entirety. -->

### Description
Fixes a bug that would cause the worker thread to hold a reference to a task until another task replaces it due to an oversight in where the std::shared_ptr was allocated. By explicitly clearingthe pointer, we can prevent this unwanted reference from existing after the work has finished.
<!-- Describe your changes in as much detail as possible. -->
<!-- But please exclude your personal history from this. Only describe the changes -->

### Related Issues
<!-- - #0000 Name of Issue -->
<!-- - #0001 Name of Issue -->
