### PR TITLE
ui: Fix support for disambiguation in translations

### DIFF
--- a/source/ui/ui.cpp
+++ b/source/ui/ui.cpp
@@ -209,9 +209,17 @@ streamfx::ui::translator::~translator() {}
 QString streamfx::ui::translator::translate(const char* context, const char* sourceText, const char* disambiguation,
 											int n) const
 {
-	std::string_view sourceView{sourceText};
-	if (sourceView.substr(0, _i18n_prefix.length()) == _i18n_prefix) {
-		return QString::fromUtf8(D_TRANSLATE(sourceView.substr(_i18n_prefix.length()).data()));
+	if (sourceText) {
+		std::string_view sourceView{sourceText};
+		if (sourceView.substr(0, _i18n_prefix.length()) == _i18n_prefix) {
+			return QString::fromUtf8(D_TRANSLATE(sourceView.substr(_i18n_prefix.length()).data()));
+		}
+	}
+	if (disambiguation) {
+		std::string_view disambiguationView{disambiguation};
+		if (disambiguationView.substr(0, _i18n_prefix.length()) == _i18n_prefix) {
+			return QString::fromUtf8(D_TRANSLATE(disambiguationView.substr(_i18n_prefix.length()).data()));
+		}
 	}
 	return QString();
 }


### PR DESCRIPTION
<!-- Hi, thank you for taking the time to submit a pull request. -->
<!-- Please make sure that you fill this out in it's entirety. -->

### Description
Fixes a potential crash if sourceTex is null, and adds support for disambiguation translation. This allows us to create UI files with test text, while still supporting real translations.
<!-- Describe your changes in as much detail as possible. -->
<!-- But please exclude your personal history from this. Only describe the changes -->

### Related Issues
<!-- - #0000 Name of Issue -->
<!-- - #0001 Name of Issue -->
