### PR TITLE
Don't include installer/version files in win32 output if native build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -562,15 +562,17 @@ list(APPEND PROJECT_PRIVATE_GENERATED
 	"${PROJECT_BINARY_DIR}/generated/config.hpp"
 )
 if(WIN32)
-	list(APPEND PROJECT_TEMPLATES
-		"templates/installer.iss.in"
-		"templates/version.rc.in"
-	)
+	if(NOT TARGET libobs)
+		list(APPEND PROJECT_TEMPLATES
+			"templates/installer.iss.in"
+			"templates/version.rc.in"
+		)
+		list(APPEND PROJECT_PRIVATE_GENERATED
+			"${PROJECT_BINARY_DIR}/generated/version.rc"
+		)
+	endif()
 	list(APPEND PROJECT_PRIVATE_SOURCE
 		"source/windll.cpp"
-	)
-	list(APPEND PROJECT_PRIVATE_GENERATED
-		"${PROJECT_BINARY_DIR}/generated/version.rc"
 	)
 endif()
 if((CMAKE_C_COMPILER_ID STREQUAL "GNU")


### PR DESCRIPTION
### Issue
When building natively against OBS on Windows, CMake errors looking for a file that has not been generated:
```
CMake Error at plugins/streamfx/CMakeLists.txt:945 (add_library):
  Cannot find source file:

    C:/Users/dprei/src/Github/obs-studio/build/plugins/streamfx/generated/version.rc

  Tried extensions .c .C .c++ .cc .cpp .cxx .cu .m .M .mm .h .hh .h++ .hm
  .hpp .hxx .in .txx


CMake Error at plugins/streamfx/CMakeLists.txt:945 (add_library):
  No SOURCES given to target: StreamFX
```

### Description
StreamFX only generates these files if we're not targeting a native build against OBS. This change simply matches these definitions with those above.