### PR TITLE
ui/updater: Apply workaround for OBS Studio checking for modals

### DIFF
--- a/source/ui/ui-updater.cpp
+++ b/source/ui/ui-updater.cpp
@@ -103,7 +103,14 @@ void streamfx::ui::updater_dialog::show(streamfx::update_info current, streamfx:
 
 	_update_url = QUrl(QString::fromStdString(update.url));
 
+	this->setModal(true);
 	QDialog::show();
+}
+
+void streamfx::ui::updater_dialog::hide()
+{
+	this->setModal(false);
+	QDialog::hide();
 }
 
 void streamfx::ui::updater_dialog::on_ok()
@@ -121,14 +128,6 @@ streamfx::ui::updater::updater(QMenu* menu)
 {
 	// Create dialog.
 	_dialog = new updater_dialog();
-
-	// Create GitHub message box.
-	_gdpr = new QMessageBox(reinterpret_cast<QWidget*>(obs_frontend_get_main_window()));
-	_gdpr->setWindowTitle(QString::fromUtf8(D_TRANSLATE(D_I18N_GITHUBPERMISSION_TITLE)));
-	_gdpr->setTextFormat(Qt::TextFormat::RichText);
-	_gdpr->setText(QString::fromUtf8(D_TRANSLATE(D_I18N_GITHUBPERMISSION_TEXT)));
-	_gdpr->setStandardButtons(QMessageBox::Ok | QMessageBox::Cancel);
-	connect(_gdpr, &QMessageBox::buttonClicked, this, &streamfx::ui::updater::on_gdpr_button);
 
 	{ // Create the necessary menu entries.
 		menu->addSeparator();
@@ -179,6 +178,7 @@ streamfx::ui::updater::updater(QMenu* menu)
 			if (_updater->gdpr()) {
 				_updater->refresh();
 			} else {
+				create_gdpr_box();
 				_gdpr->exec();
 			}
 		}
@@ -243,6 +243,7 @@ void streamfx::ui::updater::on_gdpr_button(QAbstractButton* btn)
 void streamfx::ui::updater::on_cfu_triggered(bool)
 {
 	if (!_updater->gdpr()) {
+		create_gdpr_box();
 		_gdpr->exec();
 	} else {
 		emit check_active(true);
@@ -286,4 +287,20 @@ void streamfx::ui::updater::on_check_active(bool active)
 	_channel_preview->setEnabled(!active);
 	_channel_stable->setEnabled(!active);
 	_channel_menu->setEnabled(!active);
+}
+
+void streamfx::ui::updater::create_gdpr_box()
+{
+	if (_gdpr) {
+		_gdpr->deleteLater();
+		_gdpr = nullptr;
+	}
+
+	// Create GitHub message box.
+	_gdpr = new QMessageBox(reinterpret_cast<QWidget*>(obs_frontend_get_main_window()));
+	_gdpr->setWindowTitle(QString::fromUtf8(D_TRANSLATE(D_I18N_GITHUBPERMISSION_TITLE)));
+	_gdpr->setTextFormat(Qt::TextFormat::RichText);
+	_gdpr->setText(QString::fromUtf8(D_TRANSLATE(D_I18N_GITHUBPERMISSION_TEXT)));
+	_gdpr->setStandardButtons(QMessageBox::Ok | QMessageBox::Cancel);
+	connect(_gdpr, &QMessageBox::buttonClicked, this, &streamfx::ui::updater::on_gdpr_button);
 }

--- a/source/ui/ui-updater.hpp
+++ b/source/ui/ui-updater.hpp
@@ -54,6 +54,7 @@ namespace streamfx::ui {
 		~updater_dialog();
 
 		void show(streamfx::update_info current, streamfx::update_info update);
+		void hide();
 
 		public slots:
 		; // Needed by some linters.
@@ -82,6 +83,8 @@ namespace streamfx::ui {
 		public:
 		updater(QMenu* menu);
 		~updater();
+
+		void create_gdpr_box();
 
 		void on_updater_automation_changed(streamfx::updater&, bool);
 		void on_updater_channel_changed(streamfx::updater&, streamfx::update_channel);

--- a/ui/updater.ui
+++ b/ui/updater.ui
@@ -41,7 +41,7 @@ QWidget[objectName=&quot;ok&quot;]:hover {
 }</string>
   </property>
   <property name="modal">
-   <bool>true</bool>
+   <bool>false</bool>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <property name="spacing">


### PR DESCRIPTION
<!-- Hi, thank you for taking the time to submit a pull request. -->
<!-- Please make sure that you fill this out in it's entirety. -->

### Description
In order to work around a bug in the OBS Studio UI code, we have to swap our modal status right before showing and right after hiding, so that the OBS Studio tray menu continuous working correctly. This is a bit of a weird solution, but it does work as expected.

<!-- Describe your changes in as much detail as possible. -->
<!-- But please exclude your personal history from this. Only describe the changes -->

### Related Issues
- #343 "Hide" option in tray menu not working.
- [obs-studio/#3518](https://github.com/obsproject/obs-studio/issues/3518) OBS Studio UI checks for invisible message boxes and modals.
<!-- - #0000 Name of Issue -->
<!-- - #0001 Name of Issue -->
