### PR TITLE
debug handler's to_string(): Return something by default

### DIFF
--- a/source/encoders/handlers/debug_handler.cpp
+++ b/source/encoders/handlers/debug_handler.cpp
@@ -40,7 +40,10 @@ using namespace streamfx::encoder::ffmpeg::handler;
 void debug_handler::get_defaults(obs_data_t*, const AVCodec*, AVCodecContext*, bool) {}
 
 template<typename T>
-std::string to_string(T value){};
+std::string to_string(T value)
+{
+	return std::string("Error: to_string not implemented for this type!");
+};
 
 template<>
 std::string to_string(int64_t value)


### PR DESCRIPTION
<!-- Hi, thank you for taking the time to submit a pull request. -->
<!-- Please make sure that you fill this out in it's entirety. -->

### Description
Not returning anything is illegal. Triggers a compiler error with
strict flags.

### Related Issues
None