### PR TITLE
Corrected value for deg30

### DIFF
--- a/data/examples/shaders/filter/hexagonize.effect
+++ b/data/examples/shaders/filter/hexagonize.effect
@@ -59,7 +59,7 @@ VertData VSDefault(VertData v_in) {
 
 #define PI		3.1415926f
 #define TAU		6.2831853f
-#define deg30	0.20943951
+#define deg30	0.52359877
 
 float hexDist(float2 a, float2 b){
 	float2 p = abs(b-a);


### PR DESCRIPTION
<!-- Hi, thank you for taking the time to submit a pull request. -->
<!-- Please make sure that you fill this out in it's entirety. -->

### Description
<!-- Describe your changes in as much detail as possible. -->
<!-- But please exclude your personal history from this. Only describe the changes -->
Current Hexagonize effect creates hexagons with incorrect angles. This is due to an incorrect value for deg30.
Should be pi/6 radians, not pi/15 radians.

### Related Issues
<!-- - #0000 Name of Issue -->
<!-- - #0001 Name of Issue -->
