### PR TITLE
ui/updater: Always initialize members to zero

### DIFF
--- a/source/ui/ui-updater.cpp
+++ b/source/ui/ui-updater.cpp
@@ -125,6 +125,8 @@ void streamfx::ui::updater_dialog::on_cancel()
 }
 
 streamfx::ui::updater::updater(QMenu* menu)
+	: _updater(), _dialog(nullptr), _gdpr(nullptr), _cfu(nullptr), _cfu_auto(nullptr), _channel(nullptr),
+	  _channel_menu(nullptr), _channel_stable(nullptr), _channel_preview(nullptr), _channel_group(nullptr)
 {
 	// Create dialog.
 	_dialog = new updater_dialog();


### PR DESCRIPTION
<!-- Hi, thank you for taking the time to submit a pull request. -->
<!-- Please make sure that you fill this out in it's entirety. -->

### Description
Initializes all updater variables to 0 in order to fix a crash.
<!-- Describe what the PR does in detail, and why this is necessary. -->
<!-- Please do not include any personal history, or personal reasons - keep things objective, not subjective. -->

#### Old Behavior
OBS Studio may crash on launch if StreamFX is installed.
<!-- Describe the old behavior -->
<!-- Attach videos or screenshots of the old behavior -->

#### New Behavior
OBS Studio no longer crashes on launch.
<!-- Describe the new behavior -->
<!-- Attach videos or screenshots of the new behavior -->

### Related Issues
<!-- Is this PR related to another PR or Issue? List them here. -->
<!-- - #0000 Name of Issue -->
<!-- - #0001 Name of Issue -->
