### PR TITLE
ui/updater: Set modal flag after hiding the dialog

### DIFF
--- a/source/ui/ui-updater.cpp
+++ b/source/ui/ui-updater.cpp
@@ -109,8 +109,8 @@ void streamfx::ui::updater_dialog::show(streamfx::update_info current, streamfx:
 
 void streamfx::ui::updater_dialog::hide()
 {
-	this->setModal(false);
 	QDialog::hide();
+	this->setModal(false);
 }
 
 void streamfx::ui::updater_dialog::on_ok()


### PR DESCRIPTION
<!-- Hi, thank you for taking the time to submit a pull request. -->
<!-- Please make sure that you fill this out in it's entirety. -->

### Description
This fixes a bug with older Qt versions which would not remove the modal window from the parent in the setModal() call, resulting in an unusable parent window.
<!-- Describe what the PR does in detail, and why this is necessary. -->
<!-- Please do not include any personal history, or personal reasons - keep things objective, not subjective. -->

#### Old Behavior
Clicking anything but the "X" of the dialog causes OBS to enter an unusable state due to an old Qt version being used.
<!-- Describe the old behavior -->
<!-- Attach videos or screenshots of the old behavior -->

#### New Behavior
Clicking any of the close options correctly hides the dialog, so that the modal is no longer blocking OBS from being used.
<!-- Describe the new behavior -->
<!-- Attach videos or screenshots of the new behavior -->

### Related Issues
<!-- Is this PR related to another PR or Issue? List them here. -->
<!-- - #0000 Name of Issue -->
<!-- - #0001 Name of Issue -->
- #368 OBS Studio is blocked by an invisible modal