### PR TITLE
cmake: Restore default visibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -173,12 +173,12 @@ elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL 
 	message(STATUS "Applying custom flags for GNU style build.")
 	
 	# Clang/AppleClang/GNU
-	# - Don't export by default.
+	# - Don't export by default. (Temporarily disabled)
 	# - Enable all and extra warnings.
 	
 	add_compile_options("-Wall")
 	add_compile_options("-Wextra")
-	add_compile_options("-fvisibility=hidden")
+	# add_compile_options("-fvisibility=hidden")
 endif()
 
 # C++ Standard and Extensions


### PR DESCRIPTION
<!-- Hi, thank you for taking the time to submit a pull request. -->
<!-- Please make sure that you fill this out in it's entirety. -->

### Description
The MODULE_EXPORT and EXPORT macros in libOBS do not correctly mark a function or type as visible on GCC, which results in the newly added flag hiding everything from view, instead of just what should be hidden.
<!-- Describe what the PR does in detail, and why this is necessary. -->
<!-- Please do not include any personal history, or personal reasons - keep things objective, not subjective. -->

#### Old Behavior
Linux and Mac binaries did not load.
<!-- Describe the old behavior -->
<!-- Attach videos or screenshots of the old behavior -->

#### New Behavior
Linux and Mac binaries should now load again.
<!-- Describe the new behavior -->
<!-- Attach videos or screenshots of the new behavior -->

### Related Issues
<!-- Is this PR related to another PR or Issue? List them here. -->
<!-- - #0000 Name of Issue -->
<!-- - #0001 Name of Issue -->
- #372 'obs_module_load' missing