### PR TITLE
plugin: Implement proper functions to get config and data files

### DIFF
--- a/source/plugin.cpp
+++ b/source/plugin.cpp
@@ -270,3 +270,27 @@ void streamfx::gs_draw_fullscreen_tri()
 	gs_load_vertexbuffer(_gs_fstri_vb->update(false));
 	gs_draw(GS_TRIS, 0, 3); //_gs_fstri_vb->size());
 }
+
+std::filesystem::path streamfx::data_file_path(std::string_view file)
+{
+	const char* root_path = obs_get_module_data_path(obs_current_module());
+	if (root_path) {
+		auto ret = std::filesystem::u8path(root_path);
+		ret.append(file.data());
+		return ret;
+	} else {
+		throw std::runtime_error("obs_get_module_data_path returned nullptr");
+	}
+}
+
+std::filesystem::path streamfx::config_file_path(std::string_view file)
+{
+	char* root_path = obs_module_get_config_path(obs_current_module(), file.data());
+	if (root_path) {
+		auto ret = std::filesystem::u8path(root_path);
+		bfree(root_path);
+		return ret;
+	} else {
+		throw std::runtime_error("obs_module_get_config_path returned nullptr");
+	}
+}

--- a/source/plugin.hpp
+++ b/source/plugin.hpp
@@ -25,4 +25,7 @@ namespace streamfx {
 	std::shared_ptr<util::threadpool> threadpool();
 
 	void gs_draw_fullscreen_tri();
+
+	std::filesystem::path data_file_path(std::string_view file);
+	std::filesystem::path config_file_path(std::string_view file);
 } // namespace streamfx


### PR DESCRIPTION
<!-- Hi, thank you for taking the time to submit a pull request. -->
<!-- Please make sure that you fill this out in it's entirety. -->

### Description
Using the obs_module_file and obs_module_config_path macros works okay, but it comes with a slight overhead as well as additional requirements when passing it to C++ functions that expect certain rules to be fulfilled. By instead wrapping the actual functionality into our own functions and using those we can avoid most of the issues that come with the old approach.
<!-- Describe what the PR does in detail, and why this is necessary. -->
<!-- Please do not include any personal history, or personal reasons - keep things objective, not subjective. -->

#### Old Behavior
The old behavior incorrectly relied on C++ to consider char* as a unicode string and would have a lot of boilerplate code repeated over many places.
<!-- Describe the old behavior -->
<!-- Attach videos or screenshots of the old behavior -->

#### New Behavior
Failure cases are properly handled, as well as unicode characters.
<!-- Describe the new behavior -->
<!-- Attach videos or screenshots of the new behavior -->

### Related Issues
<!-- Is this PR related to another PR or Issue? List them here. -->
<!-- - #0000 Name of Issue -->
<!-- - #0001 Name of Issue -->
- #359 Configuration is not saved in the correct directory.
