### PR TITLE
ui/updater: Don't require Qt interaction before OBS is ready

### DIFF
--- a/source/ui/ui-updater.cpp
+++ b/source/ui/ui-updater.cpp
@@ -176,14 +176,6 @@ streamfx::ui::updater::updater(QMenu* menu)
 													   std::placeholders::_1, std::placeholders::_2));
 		_updater->events.refreshed.add(
 			std::bind(&streamfx::ui::updater::on_updater_refreshed, this, std::placeholders::_1));
-		if (_updater->automation()) {
-			if (_updater->gdpr()) {
-				_updater->refresh();
-			} else {
-				create_gdpr_box();
-				_gdpr->exec();
-			}
-		}
 
 		// Sync with updater information.
 		emit autoupdate_changed(_updater->automation());
@@ -211,6 +203,18 @@ void streamfx::ui::updater::on_updater_refreshed(streamfx::updater&)
 		return;
 
 	emit update_detected();
+}
+
+void streamfx::ui::updater::obs_ready()
+{
+	if (_updater->automation()) {
+		if (_updater->gdpr()) {
+			_updater->refresh();
+		} else {
+			create_gdpr_box();
+			_gdpr->exec();
+		}
+	}
 }
 
 void streamfx::ui::updater::on_channel_changed(streamfx::update_channel channel)

--- a/source/ui/ui-updater.hpp
+++ b/source/ui/ui-updater.hpp
@@ -90,6 +90,8 @@ namespace streamfx::ui {
 		void on_updater_channel_changed(streamfx::updater&, streamfx::update_channel);
 		void on_updater_refreshed(streamfx::updater&);
 
+		void obs_ready();
+
 		signals:
 		; // Needed by some linters.
 

--- a/source/ui/ui.cpp
+++ b/source/ui/ui.cpp
@@ -156,6 +156,9 @@ void streamfx::ui::handler::on_obs_loaded()
 		_about_dialog->show();
 		have_shown_about_streamfx(true);
 	}
+
+	// Let the Updater start its work.
+	this->_updater->obs_ready();
 }
 
 void streamfx::ui::handler::on_action_report_issue(bool)


### PR DESCRIPTION
<!-- Hi, thank you for taking the time to submit a pull request. -->
<!-- Please make sure that you fill this out in it's entirety. -->

### Description
Fixes a launch freeze caused by the GDPR dialog. Reported by R1CH and several other users.
<!-- Describe what the PR does in detail, and why this is necessary. -->
<!-- Please do not include any personal history, or personal reasons - keep things objective, not subjective. -->

#### Old Behavior
OBS Studio occasionally froze while starting up due to the GDPR dialog appearing too early.
<!-- Describe the old behavior -->
<!-- Attach videos or screenshots of the old behavior -->

#### New Behavior
The updater now waits for OBS Studio to be fully loaded, and then performs its actual work.
<!-- Describe the new behavior -->
<!-- Attach videos or screenshots of the new behavior -->

### Related Issues
<!-- Is this PR related to another PR or Issue? List them here. -->
<!-- - #0000 Name of Issue -->
<!-- - #0001 Name of Issue -->
