### PR TITLE
ci: Remove automatic build support for Ubuntu 18.04

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -92,24 +92,9 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        ubuntu: [ bionic, focal ]
+        ubuntu: [ focal ]
         compiler: [ gcc, clang ]
         include:
-          - ubuntu: bionic
-            compiler: gcc
-            compiler-cxx: g++
-            runner: ubuntu-18.04
-            packages: gcc-8 g++8
-            extra_command: sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 800 --slave /usr/bin/g++ g++ /usr/bin/g++-8
-            id: ubuntu-18.04
-          - ubuntu: bionic
-            compiler: clang
-            compiler-cxx: clang++
-            compiler-version: 8
-            runner: ubuntu-18.04
-            packages: clang-8 clang-format-8 clang-tidy-8
-            extra_command: ""
-            id: ubuntu-18.04-clang
           - ubuntu: focal
             compiler: gcc
             compiler-cxx: g++


### PR DESCRIPTION
<!-- Hi, thank you for taking the time to submit a pull request. -->
<!-- Please make sure that you fill this out in it's entirety. -->

### Description
The majority of users should have already switched or upgraded to Ubuntu 20.04 at this point, so there is no point in building further Ubuntu 18.04 versions. This saves us some CI slots, and also reduces the number of target systems to actually support.
<!-- Describe what the PR does in detail, and why this is necessary. -->
<!-- Please do not include any personal history, or personal reasons - keep things objective, not subjective. -->

#### Old Behavior
<!-- Describe the old behavior -->
<!-- Attach videos or screenshots of the old behavior -->

#### New Behavior
<!-- Describe the new behavior -->
<!-- Attach videos or screenshots of the new behavior -->

### Related Issues
<!-- Is this PR related to another PR or Issue? List them here. -->
<!-- - #0000 Name of Issue -->
<!-- - #0001 Name of Issue -->
