### PR TITLE
Fix various CMake issues

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1185,7 +1185,7 @@ if(T_CHECK)
 endif()
 
 # Filter/Transform
-is_feature_enabled(FILTER_TRANFORM T_CHECK)
+is_feature_enabled(FILTER_TRANSFORM T_CHECK)
 if(T_CHECK)
 	list(APPEND PROJECT_PRIVATE_SOURCE
 		"source/filters/filter-transform.hpp"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -505,9 +505,9 @@ function(is_feature_enabled FEATURE OUTPUT)
 	endif()
 endfunction()
 
-function(set_feature_disabled FEATURE DISABLED)
+macro(set_feature_disabled FEATURE DISABLED)
 	set(${PREFIX}DISABLE_${FEATURE} ${DISABLED} PARENT_SCOPE)
-endfunction()
+endmacro()
 
 # Features
 function(feature_encoder_ffmpeg RESOLVE)
@@ -712,8 +712,9 @@ if(REQUIRE_JSON)
 	endif()
 endif()
 
+# NVIDIA Augmented Reality SDK (Windows)
 set(HAVE_NVIDIA_ARSDK OFF)
-if(REQUIRE_NVIDIA_ARSDK)
+if(REQUIRE_NVIDIA_ARSDK AND D_PLATFORM_WINDOWS)
 	if(EXISTS "${PROJECT_SOURCE_DIR}/third-party/nvidia-arsdk/version.h")
 		set(NVAR_ROOT "${PROJECT_SOURCE_DIR}/third-party/nvidia-arsdk")
 	endif()
@@ -723,8 +724,9 @@ if(REQUIRE_NVIDIA_ARSDK)
 	set(HAVE_NVIDIA_ARSDK ${NVAR_FOUND})
 endif()
 
+# NVIDIA CUDA (Windows)
 set(HAVE_NVIDIA_CUDA OFF)
-if(REQUIRE_NVIDIA_CUDA)
+if(REQUIRE_NVIDIA_CUDA AND D_PLATFORM_WINDOWS)
 	set(HAVE_NVIDIA_CUDA ON)
 endif()
 


### PR DESCRIPTION
<!-- Hi, thank you for taking the time to submit a pull request. -->
<!-- Please make sure that you fill this out in it's entirety. -->

### Description
Fixes various discovered CMake issues, such as CMake not propagating PARENT_SCOPE changes to the actual parent due to forgetting to use a `macro()`.
<!-- Describe what the PR does in detail, and why this is necessary. -->
<!-- Please do not include any personal history, or personal reasons - keep things objective, not subjective. -->

#### Old Behavior
- The 3D Transform Filter wasn't built due to a typo.
- Some automatic disabling of a feature was not triggered.
- Some Windows-exclusive libraries were included automatically on non-Windows platforms.
<!-- Describe the old behavior -->
<!-- Attach videos or screenshots of the old behavior -->

#### New Behavior
- The 3D Transform Filter is now built again.
- Automatic disabling of features works again.
- No Windows-exclusive libraries are included anymore.
<!-- Describe the new behavior -->
<!-- Attach videos or screenshots of the new behavior -->

### Related Issues
<!-- Is this PR related to another PR or Issue? List them here. -->
- #434 
- #458 
- #460 
- #461 
- #462 
- #463 
- #465 Linux Obstacles with ARM64
<!-- - #0000 Name of Issue -->
<!-- - #0001 Name of Issue -->
