### PR TITLE
nvidia/cuda: Use reinterpret_case instead of static_cast

### DIFF
--- a/source/nvidia/cuda/nvidia-cuda.cpp
+++ b/source/nvidia/cuda/nvidia-cuda.cpp
@@ -29,19 +29,19 @@
 
 #define CUDA_LOAD_SYMBOL(NAME)                                                            \
 	{                                                                                     \
-		NAME = static_cast<decltype(NAME)>(os_dlsym(_library, #NAME));                    \
+		NAME = reinterpret_cast<decltype(NAME)>(os_dlsym(_library, #NAME));                    \
 		if (!NAME)                                                                        \
 			throw std::runtime_error("Failed to load '" #NAME "' from '" CUDA_NAME "'."); \
 	}
 #define CUDA_LOAD_SYMBOL_V2(NAME)                                                         \
 	{                                                                                     \
-		NAME = static_cast<decltype(NAME)>(os_dlsym(_library, #NAME "_v2"));              \
+		NAME = reinterpret_cast<decltype(NAME)>(os_dlsym(_library, #NAME "_v2"));              \
 		if (!NAME)                                                                        \
 			throw std::runtime_error("Failed to load '" #NAME "' from '" CUDA_NAME "'."); \
 	}
 #define CUDA_LOAD_SYMBOL_EX(NAME, OVERRIDE)                                               \
 	{                                                                                     \
-		NAME = static_cast<decltype(NAME)>(os_dlsym(_library, #OVERRIDE));                \
+		NAME = reinterpret_cast<decltype(NAME)>(os_dlsym(_library, #OVERRIDE));                \
 		if (!NAME)                                                                        \
 			throw std::runtime_error("Failed to load '" #NAME "' from '" CUDA_NAME "'."); \
 	}


### PR DESCRIPTION
<!-- Hi, thank you for taking the time to submit a pull request. -->
<!-- Please make sure that you fill this out in it's entirety. -->

### Description
Some GCC versions complain about void* to any* casts. 
<!-- Describe what the PR does in detail, and why this is necessary. -->
<!-- Please do not include any personal history, or personal reasons - keep things objective, not subjective. -->

#### Old Behavior
<!-- Describe the old behavior -->
<!-- Attach videos or screenshots of the old behavior -->

#### New Behavior
<!-- Describe the new behavior -->
<!-- Attach videos or screenshots of the new behavior -->

### Related Issues
<!-- Is this PR related to another PR or Issue? List them here. -->
<!-- - #0000 Name of Issue -->
<!-- - #0001 Name of Issue -->
- #465