### PR TITLE
ffmpeg/tools: Fix incorrect transfer characteristics

### DIFF
--- a/source/ffmpeg/tools.cpp
+++ b/source/ffmpeg/tools.cpp
@@ -172,12 +172,12 @@ AVColorTransferCharacteristic ffmpeg::tools::obs_to_av_color_transfer_characteri
 {
 	switch (v) {
 	case VIDEO_CS_601:
-		return AVCOL_TRC_LINEAR;
+		return AVCOL_TRC_SMPTE240M;
 	case VIDEO_CS_DEFAULT:
 	case VIDEO_CS_709:
 		return AVCOL_TRC_BT709;
-	case VIDEO_CS_SRGB:
-		return AVCOL_TRC_IEC61966_2_1;
+	case VIDEO_CS_SRGB: // sRGB with Gamma 2.2
+		return AVCOL_TRC_GAMMA22;
 	default:
 		throw std::invalid_argument("Unknown Color Transfer Characteristics");
 	}


### PR DESCRIPTION
<!-- Hi, thank you for taking the time to submit a pull request. -->
<!-- Please make sure that you fill this out in it's entirety. -->

### Description
Both Rec. 601 and sRGB looked extremely wrong before, resulting in weird or warped colors. Since it is very difficult to find up to date and accurate information on standards, we should simply go for what has the most widespread support.
<!-- Describe what the PR does in detail, and why this is necessary. -->
<!-- Please do not include any personal history, or personal reasons - keep things objective, not subjective. -->

#### Old Behavior
- sRGB colors were warped.
- Rec. 601 was completely wrong.
<!-- Describe the old behavior -->
<!-- Attach videos or screenshots of the old behavior -->

#### New Behavior
- Both color spaces should look "correct" now.
<!-- Describe the new behavior -->
<!-- Attach videos or screenshots of the new behavior -->

### Related Issues
<!-- Is this PR related to another PR or Issue? List them here. -->
<!-- - #0000 Name of Issue -->
<!-- - #0001 Name of Issue -->
