### PR TITLE
cmake: (Windows) Fix incorrect reference to CMAKE_PACKAGE_PREFIX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -904,12 +904,6 @@ if(D_PLATFORM_WINDOWS) # Windows Support
 	)
 	LIST(APPEND PROJECT_TEMPLATES "templates/version.rc.in")
 	LIST(APPEND PROJECT_PRIVATE_GENERATED "${PROJECT_BINARY_DIR}/generated/version.rc")
-
-	if(NOT ${PREFIX}OBS_NATIVE)
-		list(APPEND PROJECT_TEMPLATES
-			"templates/installer.iss.in"
-		)
-	endif()
 endif()
 
 # Minimum Dependencies
@@ -1794,7 +1788,7 @@ if(NOT ${PREFIX}OBS_NATIVE)
 			get_filename_component(ISS_FILES_DIR "${CMAKE_INSTALL_PREFIX}" ABSOLUTE)
 			file(TO_NATIVE_PATH "${ISS_FILES_DIR}" ISS_FILES_DIR)
 
-			get_filename_component(ISS_PACKAGE_DIR "${CMAKE_PACKAGE_PREFIX}" ABSOLUTE)
+			get_filename_component(ISS_PACKAGE_DIR "${PACKAGE_PREFIX}" ABSOLUTE)
 			file(TO_NATIVE_PATH "${ISS_PACKAGE_DIR}" ISS_PACKAGE_DIR)
 
 			get_filename_component(ISS_SOURCE_DIR "${PROJECT_SOURCE_DIR}" ABSOLUTE)


### PR DESCRIPTION
<!-- Hi, thank you for taking the time to submit a pull request. -->
<!-- Please make sure that you fill this out in it's entirety. -->

### Description
<!-- Describe what the PR does in detail, and why this is necessary. -->
<!-- Please do not include any personal history, or personal reasons - keep things objective, not subjective. -->

#### Old Behavior
The Windows installer was placed in the wrong directory.
<!-- Describe the old behavior -->
<!-- Attach videos or screenshots of the old behavior -->

#### New Behavior
The Windows installer is now in the correct place again.
<!-- Describe the new behavior -->
<!-- Attach videos or screenshots of the new behavior -->

### Related Issues
<!-- Is this PR related to another PR or Issue? List them here. -->
<!-- - #0000 Name of Issue -->
<!-- - #0001 Name of Issue -->
