### PR TITLE
Enable Direct Rendering for Sources and Filters that support it

### DIFF
--- a/source/filters/filter-color-grade.cpp
+++ b/source/filters/filter-color-grade.cpp
@@ -321,7 +321,7 @@ void color_grade_instance::video_tick(float)
 	_cache_fresh  = false;
 }
 
-void color_grade_instance::video_render(gs_effect_t*)
+void color_grade_instance::video_render(gs_effect_t* shader)
 {
 	// Grab initial values.
 	obs_source_t* parent = obs_filter_get_parent(_self);
@@ -329,6 +329,7 @@ void color_grade_instance::video_render(gs_effect_t*)
 	uint32_t      width  = obs_source_get_base_width(target);
 	uint32_t      height = obs_source_get_base_height(target);
 	vec4          blank  = vec4{0, 0, 0, 0};
+	shader               = shader ? shader : obs_get_base_effect(OBS_EFFECT_DEFAULT);
 
 	// Skip filter if anything is wrong.
 	if (!parent || !target || !width || !height) {
@@ -525,8 +526,6 @@ void color_grade_instance::video_render(gs_effect_t*)
 #ifdef ENABLE_PROFILING
 		gs::debug_marker gdm{gs::debug_color_cache_render, "Draw Cache"};
 #endif
-		auto shader = obs_get_base_effect(OBS_EFFECT_DEFAULT);
-
 		// Revert GPU status to what OBS Studio expects.
 		gs_enable_depth_test(false);
 		gs_enable_color(true, true, true, true);
@@ -545,7 +544,7 @@ color_grade_factory::color_grade_factory()
 {
 	_info.id           = PREFIX "filter-color-grade";
 	_info.type         = OBS_SOURCE_TYPE_FILTER;
-	_info.output_flags = OBS_SOURCE_VIDEO | OBS_SOURCE_CUSTOM_DRAW;
+	_info.output_flags = OBS_SOURCE_VIDEO;
 
 	set_resolution_enabled(false);
 	finish_setup();

--- a/source/filters/filter-displacement.cpp
+++ b/source/filters/filter-displacement.cpp
@@ -118,7 +118,7 @@ displacement_factory::displacement_factory()
 {
 	_info.id           = PREFIX "filter-displacement";
 	_info.type         = OBS_SOURCE_TYPE_FILTER;
-	_info.output_flags = OBS_SOURCE_VIDEO;
+	_info.output_flags = OBS_SOURCE_VIDEO | OBS_SOURCE_CUSTOM_DRAW;
 
 	set_resolution_enabled(false);
 	finish_setup();

--- a/source/filters/filter-dynamic-mask.cpp
+++ b/source/filters/filter-dynamic-mask.cpp
@@ -393,7 +393,7 @@ dynamic_mask_factory::dynamic_mask_factory()
 {
 	_info.id           = PREFIX "filter-dynamic-mask";
 	_info.type         = OBS_SOURCE_TYPE_FILTER;
-	_info.output_flags = OBS_SOURCE_VIDEO;
+	_info.output_flags = OBS_SOURCE_VIDEO | OBS_SOURCE_CUSTOM_DRAW;
 
 	set_have_active_child_sources(true);
 	set_have_child_sources(true);

--- a/source/filters/filter-shader.cpp
+++ b/source/filters/filter-shader.cpp
@@ -126,7 +126,7 @@ void shader_instance::video_render(gs_effect_t* effect)
 
 			_fx->prepare_render();
 			_fx->set_input_a(_rt->get_texture());
-			_fx->render();
+			_fx->render(effect);
 		}
 	} catch (const std::exception& ex) {
 		obs_source_skip_video_filter(_self);
@@ -148,7 +148,7 @@ shader_factory::shader_factory()
 {
 	_info.id           = PREFIX "filter-shader";
 	_info.type         = OBS_SOURCE_TYPE_FILTER;
-	_info.output_flags = OBS_SOURCE_VIDEO | OBS_SOURCE_CUSTOM_DRAW;
+	_info.output_flags = OBS_SOURCE_VIDEO;
 
 	set_activity_tracking_enabled(true);
 	finish_setup();

--- a/source/gfx/shader/gfx-shader.cpp
+++ b/source/gfx/shader/gfx-shader.cpp
@@ -508,10 +508,13 @@ void gfx::shader::shader::prepare_render()
 	return;
 }
 
-void gfx::shader::shader::render()
+void gfx::shader::shader::render(gs_effect* effect)
 {
 	if (!_shader)
 		return;
+
+	if (!effect)
+		effect = obs_get_base_effect(OBS_EFFECT_DEFAULT);
 
 	if (!_rt_up_to_date) {
 		auto op   = _rt->render(width(), height());
@@ -534,9 +537,8 @@ void gfx::shader::shader::render()
 		_rt_up_to_date = true;
 	}
 
-	gs_effect_set_texture(gs_effect_get_param_by_name(obs_get_base_effect(OBS_EFFECT_DEFAULT), "image"),
-						  _rt->get_texture()->get_object());
-	while (gs_effect_loop(obs_get_base_effect(OBS_EFFECT_DEFAULT), "Draw")) {
+	gs_effect_set_texture(gs_effect_get_param_by_name(effect, "image"), _rt->get_texture()->get_object());
+	while (gs_effect_loop(effect, "Draw")) {
 		gs_draw_sprite(nullptr, 0, width(), height());
 	}
 }

--- a/source/gfx/shader/gfx-shader.hpp
+++ b/source/gfx/shader/gfx-shader.hpp
@@ -112,7 +112,7 @@ namespace gfx {
 
 			void prepare_render();
 
-			void render();
+			void render(gs_effect* effect);
 
 			public:
 			void set_size(uint32_t w, uint32_t h);

--- a/source/sources/source-shader.cpp
+++ b/source/sources/source-shader.cpp
@@ -84,7 +84,7 @@ void shader_instance::video_render(gs_effect_t* effect)
 #endif
 
 	_fx->prepare_render();
-	_fx->render();
+	_fx->render(effect);
 }
 
 void streamfx::source::shader::shader_instance::activate()
@@ -101,7 +101,7 @@ shader_factory::shader_factory()
 {
 	_info.id           = PREFIX "source-shader";
 	_info.type         = OBS_SOURCE_TYPE_INPUT;
-	_info.output_flags = OBS_SOURCE_VIDEO | OBS_SOURCE_CUSTOM_DRAW;
+	_info.output_flags = OBS_SOURCE_VIDEO;
 
 	set_activity_tracking_enabled(true);
 	finish_setup();

--- a/source/transitions/transition-shader.cpp
+++ b/source/transitions/transition-shader.cpp
@@ -97,7 +97,7 @@ void shader_instance::transition_render(gs_texture_t* a, gs_texture_t* b, float_
 	_fx->set_transition_time(t);
 	_fx->set_transition_size(cx, cy);
 	_fx->prepare_render();
-	_fx->render();
+	_fx->render(nullptr);
 }
 
 bool shader_instance::audio_render(uint64_t* ts_out, obs_source_audio_mix* audio_output, uint32_t mixers,


### PR DESCRIPTION
<!-- Hi, thank you for taking the time to submit a pull request. -->
<!-- Please make sure that you fill this out in it's entirety. -->

### Description
See #501.
<!-- Describe what the PR does in detail, and why this is necessary. -->
<!-- Please do not include any personal history, or personal reasons - keep things objective, not subjective. -->

#### Old Behavior
- 3D Transform: Direct Rendering
- Blur: Direct Rendering
- Color Grading: Buffered Rendering
- Displacement Mapping: Direct Rendering
- Dynamic Mask: Direct Rendering
- Nvidia Face Tracking: Direct Rendering (internally buffers)
- SDF Effects: Direct Rendering (internally buffers)
- Shaders: Buffered Rendering (internally buffers)
- Source Mirror: Buffered Rendering

#### New Behavior
- 3D Transform: Direct Rendering
- Blur: Direct Rendering
- Color Grading: Direct Rendering (internally buffers)
- Displacement Mapping: Buffered Rendering
- Dynamic Mask: Buffered Rendering
- Nvidia Face Tracking: Direct Rendering (internally buffers)
- SDF Effects: Direct Rendering (internally buffers)
- Shaders: Direct Rendering (internally buffers), except Transitions
- Source Mirror: Buffered Rendering
<!-- Describe the new behavior -->
<!-- Attach videos or screenshots of the new behavior -->

### Related Issues
<!-- Is this PR related to another PR or Issue? List them here. -->
<!-- - #0000 Name of Issue -->
<!-- - #0001 Name of Issue -->
