### PR TITLE
Pass all values to translate_string in dynamic mask filter

### DIFF
--- a/source/filters/filter-dynamic-mask.cpp
+++ b/source/filters/filter-dynamic-mask.cpp
@@ -479,7 +479,7 @@ obs_properties_t* dynamic_mask_factory::get_properties2(dynamic_mask_instance* d
 			_translation_cache.push_back(translate_string(D_TRANSLATE(D_DESC(ST_CHANNEL_INPUT)), D_TRANSLATE(sec_ch),
 														  D_TRANSLATE(pri_ch), D_TRANSLATE(sec_ch), D_TRANSLATE(pri_ch),
 														  D_TRANSLATE(pri_ch), D_TRANSLATE(pri_ch), D_TRANSLATE(pri_ch),
-														  D_TRANSLATE(pri_ch), D_TRANSLATE(pri_ch)));
+														  D_TRANSLATE(pri_ch), D_TRANSLATE(pri_ch), D_TRANSLATE(pri_ch)));
 			obs_property_set_long_description(p, _translation_cache.back().c_str());
 		}
 

--- a/source/filters/filter-dynamic-mask.cpp
+++ b/source/filters/filter-dynamic-mask.cpp
@@ -476,10 +476,10 @@ obs_properties_t* dynamic_mask_factory::get_properties2(dynamic_mask_instance* d
 			std::string buf = std::string(ST_CHANNEL_INPUT) + "." + pri_ch + "." + sec_ch;
 			p = obs_properties_add_float_slider(grp, buf.c_str(), _translation_cache.back().c_str(), -100.0, 100.0,
 												0.01);
-			_translation_cache.push_back(translate_string(D_TRANSLATE(D_DESC(ST_CHANNEL_INPUT)), D_TRANSLATE(sec_ch),
-														  D_TRANSLATE(pri_ch), D_TRANSLATE(sec_ch), D_TRANSLATE(pri_ch),
-														  D_TRANSLATE(pri_ch), D_TRANSLATE(pri_ch), D_TRANSLATE(pri_ch),
-														  D_TRANSLATE(pri_ch), D_TRANSLATE(pri_ch), D_TRANSLATE(pri_ch)));
+			_translation_cache.push_back(
+				translate_string(D_TRANSLATE(D_DESC(ST_CHANNEL_INPUT)), D_TRANSLATE(sec_ch), D_TRANSLATE(pri_ch),
+								 D_TRANSLATE(sec_ch), D_TRANSLATE(pri_ch), D_TRANSLATE(pri_ch), D_TRANSLATE(pri_ch),
+								 D_TRANSLATE(pri_ch), D_TRANSLATE(pri_ch), D_TRANSLATE(pri_ch), D_TRANSLATE(pri_ch)));
 			obs_property_set_long_description(p, _translation_cache.back().c_str());
 		}
 


### PR DESCRIPTION
### Description

Pass as many arguments as there are placeholders in the format string.

#### Old Behavior

OBS crashed nondeterminsitically when adding a dynamic mask filter on some computers.

#### New Behavior

OBS does no longer crash when adding a dynamic mask filter.

### Related Issues

#491 Instant crash when adding Dynamic mask