### PR TITLE
Don't replace the OBS Studio About menu with StreamFXs

### DIFF
--- a/source/ui/ui-updater.cpp
+++ b/source/ui/ui-updater.cpp
@@ -136,20 +136,25 @@ streamfx::ui::updater::updater(QMenu* menu)
 
 		// Check for Updates
 		_cfu = menu->addAction(QString::fromUtf8(D_TRANSLATE(D_I18N_MENU_CHECKFORUPDATES)));
+		_cfu->setMenuRole(QAction::NoRole);
 		connect(_cfu, &QAction::triggered, this, &streamfx::ui::updater::on_cfu_triggered);
 
 		// Automatically check for Updates
 		_cfu_auto = menu->addAction(QString::fromUtf8(D_TRANSLATE(D_I18N_MENU_CHECKFORUPDATES_AUTOMATICALLY)));
+		_cfu_auto->setMenuRole(QAction::NoRole);
 		_cfu_auto->setCheckable(true);
 		connect(_cfu_auto, &QAction::toggled, this, &streamfx::ui::updater::on_cfu_auto_toggled);
 
 		// Update Channel
 		_channel_menu = menu->addMenu(QString::fromUtf8(D_TRANSLATE(D_I18N_MENU_CHANNEL)));
+		_channel_menu->menuAction()->setMenuRole(QAction::NoRole);
 
 		_channel_stable = _channel_menu->addAction(QString::fromUtf8(D_TRANSLATE(D_I18N_MENU_CHANNEL_RELEASE)));
+		_channel_stable->setMenuRole(QAction::NoRole);
 		_channel_stable->setCheckable(true);
 
 		_channel_preview = _channel_menu->addAction(QString::fromUtf8(D_TRANSLATE(D_I18N_MENU_CHANNEL_TESTING)));
+		_channel_preview->setMenuRole(QAction::NoRole);
 		_channel_preview->setCheckable(true);
 
 		_channel_group = new QActionGroup(_channel_menu);

--- a/source/ui/ui.cpp
+++ b/source/ui/ui.cpp
@@ -158,12 +158,20 @@ void streamfx::ui::handler::on_obs_loaded()
 		connect(_about_action, &QAction::triggered, this, &streamfx::ui::handler::on_action_about);
 	}
 
-	// Add an actual Menu entry.
-	QMainWindow* main_widget = reinterpret_cast<QMainWindow*>(obs_frontend_get_main_window());
-	_menu_action             = new QAction(main_widget);
-	_menu_action->setMenu(_menu);
-	_menu_action->setText(QString::fromUtf8(D_TRANSLATE(_i18n_menu.data())));
-	main_widget->menuBar()->addAction(_menu_action);
+	{ // Add an actual Menu entry.
+		QMainWindow* main_widget = reinterpret_cast<QMainWindow*>(obs_frontend_get_main_window());
+		_menu_action             = new QAction(main_widget);
+		_menu_action->setMenu(_menu);
+		_menu_action->setText(QString::fromUtf8(D_TRANSLATE(_i18n_menu.data())));
+
+		// For unknown reasons, the "About StreamFX" menu replaces the OBS about menu.
+		QList<QMenu*> obs_menus = main_widget->menuBar()->findChildren<QMenu*>(QString(), Qt::FindDirectChildrenOnly);
+		if (QMenu* help_menu = obs_menus.at(1); help_menu) {
+			main_widget->menuBar()->insertAction(help_menu->menuAction(), _menu_action);
+		} else {
+			main_widget->menuBar()->addAction(_menu_action);
+		}
+	}
 
 	// Show the 'About StreamFX' dialog if that has not happened yet.
 	if (!have_shown_about_streamfx()) {

--- a/source/ui/ui.cpp
+++ b/source/ui/ui.cpp
@@ -126,24 +126,29 @@ void streamfx::ui::handler::on_obs_loaded()
 
 		// Report an Issue
 		_report_issue = _menu->addAction(QString::fromUtf8(D_TRANSLATE(_i18n_menu_report_issue.data())));
+		_report_issue->setMenuRole(QAction::NoRole);
 		connect(_report_issue, &QAction::triggered, this, &streamfx::ui::handler::on_action_report_issue);
 
 		// Request help
 		_request_help = _menu->addAction(QString::fromUtf8(D_TRANSLATE(_i18n_menu_request_help.data())));
+		_request_help->setMenuRole(QAction::NoRole);
 		connect(_request_help, &QAction::triggered, this, &streamfx::ui::handler::on_action_request_help);
 
 		_menu->addSeparator();
 
 		// Website
 		_link_website = _menu->addAction(QString::fromUtf8(D_TRANSLATE(_i18n_menu_website.data())));
+		_link_website->setMenuRole(QAction::NoRole);
 		connect(_link_website, &QAction::triggered, this, &streamfx::ui::handler::on_action_website);
 
 		// Discord
 		_link_discord = _menu->addAction(QString::fromUtf8(D_TRANSLATE(_i18n_menu_discord.data())));
+		_link_discord->setMenuRole(QAction::NoRole);
 		connect(_link_discord, &QAction::triggered, this, &streamfx::ui::handler::on_action_discord);
 
 		// Github
 		_link_github = _menu->addAction(QString::fromUtf8(D_TRANSLATE(_i18n_menu_github.data())));
+		_link_github->setMenuRole(QAction::NoRole);
 		connect(_link_github, &QAction::triggered, this, &streamfx::ui::handler::on_action_github);
 
 		// Create the updater.
@@ -155,12 +160,14 @@ void streamfx::ui::handler::on_obs_loaded()
 
 		// About
 		_about_action = _menu->addAction(QString::fromUtf8(D_TRANSLATE(_i18n_menu_about.data())));
+		_about_action->setMenuRole(QAction::NoRole);
 		connect(_about_action, &QAction::triggered, this, &streamfx::ui::handler::on_action_about);
 	}
 
 	{ // Add an actual Menu entry.
 		QMainWindow* main_widget = reinterpret_cast<QMainWindow*>(obs_frontend_get_main_window());
 		_menu_action             = new QAction(main_widget);
+		_menu_action->setMenuRole(QAction::NoRole);
 		_menu_action->setMenu(_menu);
 		_menu_action->setText(QString::fromUtf8(D_TRANSLATE(_i18n_menu.data())));
 


### PR DESCRIPTION
<!-- Hi, thank you for taking the time to submit a pull request. -->
<!-- Please make sure that you fill this out in it's entirety. -->

### Description
On MacOS, Qt automatically replaced the OBS Studio About with the StreamFX About window, which is not what we want. By forcefully assigning every menu item to have no actual role, we hopefully prevent this from happening.
<!-- Describe what the PR does in detail, and why this is necessary. -->
<!-- Please do not include any personal history, or personal reasons - keep things objective, not subjective. -->

#### Old Behavior
- StreamFX's About menu item replaced OBS Studio's About menu item and was not accessible.
- StreamFX's menu was the last entry.
<!-- Describe the old behavior -->
<!-- Attach videos or screenshots of the old behavior -->

#### New Behavior
- StreamFX's menu now appears in front of the Help menu.
- StreamFX's About menu item no longer replaces OBS Studio's About menu and is accessible.
<!-- Describe the new behavior -->
<!-- Attach videos or screenshots of the new behavior -->

### Related Issues
<!-- Is this PR related to another PR or Issue? List them here. -->
<!-- - #0000 Name of Issue -->
<!-- - #0001 Name of Issue -->
