### PR TITLE
Add/Implement Video Super-Resolution Filter

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "third-party/msvc-redist-helper"]
 	path = third-party/msvc-redist-helper
 	url = https://github.com/Xaymar/msvc-redist-helper.git
+[submodule "third-party/nvidia-maxine-vfx-sdk"]
+	path = third-party/nvidia-maxine-vfx-sdk
+	url = https://github.com/NVIDIA/MAXINE-VFX-SDK.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -822,6 +822,23 @@ if(REQUIRE_NVIDIA_ARSDK AND D_PLATFORM_WINDOWS)
 	set(HAVE_NVIDIA_ARSDK ${NVAR_FOUND})
 endif()
 
+#- NVIDIA Video Effects SDK
+set(HAVE_NVIDIA_VFX_SDK OFF)
+if(REQUIRE_NVIDIA_VFX_SDK AND D_PLATFORM_WINDOWS)
+	if(EXISTS "${PROJECT_SOURCE_DIR}/third-party/nvidia-maxine-vfx-sdk/version.h")
+		set(HAVE_NVIDIA_VFX_SDK ON)
+	endif()
+
+	if(NOT TARGET NVIDIA::VFX)
+		add_library(NVIDIA::VFX IMPORTED INTERFACE)
+		target_include_directories(nvARProxy
+			INTERFACE
+				"${PROJECT_SOURCE_DIR}/third-party/nvidia-maxine-vfx-sdk/nvvfx/include/"
+				"${PROJECT_SOURCE_DIR}/third-party/nvidia-maxine-vfx-sdk/nvvfx/source/"
+		)
+	endif()
+endif()
+
 #- NVIDIA CUDA (Windows)
 set(HAVE_NVIDIA_CUDA OFF)
 if(REQUIRE_NVIDIA_CUDA AND D_PLATFORM_WINDOWS)
@@ -960,7 +977,7 @@ if(HAVE_NVIDIA_ARSDK)
 	)
 endif()
 
-if(HAVE_NVIDIA_ARSDK)
+if(HAVE_NVIDIA_ARSDK OR HAVE_NVIDIA_VFX_SDK)
 	list(APPEND PROJECT_PRIVATE_SOURCE
 		"source/nvidia/cv/nvidia-cv.hpp"
 		"source/nvidia/cv/nvidia-cv.cpp"
@@ -968,6 +985,16 @@ if(HAVE_NVIDIA_ARSDK)
 		"source/nvidia/cv/nvidia-cv-image.cpp"
 		"source/nvidia/cv/nvidia-cv-texture.hpp"
 		"source/nvidia/cv/nvidia-cv-texture.cpp"
+	)
+endif()
+
+if(HAVE_NVIDIA_VFX_SDK)
+	list(APPEND PROJECT_PRIVATE_SOURCE
+		"source/nvidia/vfx/nvidia-vfx.hpp"
+		"source/nvidia/vfx/nvidia-vfx.cpp"
+	)
+	list(APPEND PROJECT_LIBRARIES
+		NVIDIA::VFX
 	)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -964,6 +964,8 @@ if(HAVE_NVIDIA_ARSDK)
 	list(APPEND PROJECT_PRIVATE_SOURCE
 		"source/nvidia/cv/nvidia-cv.hpp"
 		"source/nvidia/cv/nvidia-cv.cpp"
+		"source/nvidia/cv/nvidia-cv-image.hpp"
+		"source/nvidia/cv/nvidia-cv-image.cpp"
 	)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -966,6 +966,8 @@ if(HAVE_NVIDIA_ARSDK)
 		"source/nvidia/cv/nvidia-cv.cpp"
 		"source/nvidia/cv/nvidia-cv-image.hpp"
 		"source/nvidia/cv/nvidia-cv-image.cpp"
+		"source/nvidia/cv/nvidia-cv-texture.hpp"
+		"source/nvidia/cv/nvidia-cv-texture.cpp"
 	)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -960,6 +960,13 @@ if(HAVE_NVIDIA_ARSDK)
 	)
 endif()
 
+if(HAVE_NVIDIA_ARSDK)
+	list(APPEND PROJECT_PRIVATE_SOURCE
+		"source/nvidia/cv/nvidia-cv.hpp"
+		"source/nvidia/cv/nvidia-cv.cpp"
+	)
+endif()
+
 if(HAVE_NVIDIA_CUDA)
 	list(APPEND PROJECT_PRIVATE_SOURCE
 		"source/nvidia/cuda/nvidia-cuda.hpp"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -304,6 +304,8 @@ set(${PREFIX}ENABLE_FILTER_NVIDIA_FACE_TRACKING ON CACHE BOOL "Enable NVIDIA Fac
 set(${PREFIX}ENABLE_FILTER_SDF_EFFECTS ON CACHE BOOL "Enable SDF Effects Filter")
 set(${PREFIX}ENABLE_FILTER_SHADER ON CACHE BOOL "Enable Shader Filter")
 set(${PREFIX}ENABLE_FILTER_TRANSFORM ON CACHE BOOL "Enable Transform Filter")
+set(${PREFIX}ENABLE_FILTER_VIDEO_SUPERRESOLUTION ON CACHE BOOL "Enable Video Super-Resolution filter")
+set(${PREFIX}ENABLE_FILTER_VIDEO_SUPERRESOLUTION_NVIDIA ON CACHE BOOL "Enable NVIDIA Video Super-Resolution for Video Super-Resolution Filter")
 
 ## Sources
 set(${PREFIX}ENABLE_SOURCE_MIRROR ON CACHE BOOL "Enable Mirror Source")
@@ -681,6 +683,26 @@ function(feature_filter_transform RESOLVE)
 	is_feature_enabled(FILTER_TRANSFORM T_CHECK)
 endfunction()
 
+function(feature_filter_video_superresolution RESOLVE)
+	is_feature_enabled(FILTER_VIDEO_SUPERRESOLUTION T_CHECK)
+	if(RESOLVE AND T_CHECK)
+		# Verify that the requirements for the providers are available
+		if(NOT HAVE_NVIDIA_VFX_SDK)
+			message(WARNING "${LOGPREFIX}: 'NVIDIA Video Effects SDK' is missing. Disabling Video Super-Resolution provider...")
+			set_feature_disabled(FILTER_VIDEO_SUPERRESOLUTION_NVIDIA ON)
+		endif()
+
+		# Verify that we have at least one provider for Video Super-Resolution.
+		is_feature_enabled(FILTER_VIDEO_SUPERRESOLUTION T_CHECK_NVIDIA)
+		if (NOT T_CHECK_NVIDIA)
+			message(WARNING "${LOGPREFIX}: Video Super-Resolution has no available providers. Disabling...")
+			set_feature_disabled(FILTER_VIDEO_SUPERRESOLUTION ON)
+		endif()
+	elseif(T_CHECK)
+		set(REQUIRE_NVIDIA_VFX_SDK ON PARENT_SCOPE)
+	endif()
+endfunction()
+
 function(feature_source_mirror RESOLVE)
 	is_feature_enabled(SOURCE_MIRROR T_CHECK)
 endfunction()
@@ -735,6 +757,7 @@ feature_filter_nvidia_face_tracking(OFF)
 feature_filter_sdf_effects(OFF)
 feature_filter_shader(OFF)
 feature_filter_transform(OFF)
+feature_filter_video_superresolution(OFF)
 feature_source_mirror(OFF)
 feature_source_shader(OFF)
 feature_transition_shader(OFF)
@@ -879,6 +902,7 @@ feature_filter_nvidia_face_tracking(ON)
 feature_filter_sdf_effects(ON)
 feature_filter_shader(ON)
 feature_filter_transform(ON)
+feature_filter_video_superresolution(ON)
 feature_source_mirror(ON)
 feature_source_shader(ON)
 feature_transition_shader(ON)
@@ -992,6 +1016,8 @@ if(HAVE_NVIDIA_VFX_SDK)
 	list(APPEND PROJECT_PRIVATE_SOURCE
 		"source/nvidia/vfx/nvidia-vfx.hpp"
 		"source/nvidia/vfx/nvidia-vfx.cpp"
+		"source/nvidia/vfx/nvidia-vfx-superresolution.hpp"
+		"source/nvidia/vfx/nvidia-vfx-superresolution.cpp"
 	)
 	list(APPEND PROJECT_LIBRARIES
 		NVIDIA::VFX
@@ -1319,6 +1345,24 @@ if(T_CHECK)
 	list(APPEND PROJECT_DEFINITIONS
 		ENABLE_FILTER_TRANSFORM
 	)
+endif()
+
+# Filter/Video Super-Resolution
+is_feature_enabled(FILTER_VIDEO_SUPERRESOLUTION T_CHECK)
+if(T_CHECK)
+	list(APPEND PROJECT_PRIVATE_SOURCE
+		"source/filters/filter-video-superresolution.hpp"
+		"source/filters/filter-video-superresolution.cpp"
+	)
+	list(APPEND PROJECT_DEFINITIONS
+		ENABLE_FILTER_VIDEO_SUPERRESOLUTION
+	)
+	is_feature_enabled(FILTER_VIDEO_SUPERRESOLUTION_NVIDIA T_CHECK)
+	if (T_CHECK)
+		list(APPEND PROJECT_DEFINITIONS
+			ENABLE_FILTER_VIDEO_SUPERRESOLUTION_NVIDIA
+		)
+	endif()
 endif()
 
 # Source/Mirror

--- a/data/locale/en-US.ini
+++ b/data/locale/en-US.ini
@@ -275,6 +275,16 @@ Filter.Transform.Rotation.Order.ZXY="Roll, Pitch, Yaw"
 Filter.Transform.Rotation.Order.ZYX="Roll, Yaw, Pitch"
 Filter.Transform.Mipmapping="Enable Mipmapping"
 
+# Filter - Video Super-Resolution
+Filter.VideoSuperResolution="Video Super-Resolution"
+Filter.VideoSuperResolution.Provider="Provider"
+Filter.VideoSuperResolution.Provider.NVIDIAVideoSuperResolution="NVIDIA Video Super-Resolution, powered by NVIDIA Broadcast"
+Filter.VideoSuperResolution.NVIDIA.SuperRes="NVIDIA Video Super-Resolution"
+Filter.VideoSuperResolution.NVIDIA.SuperRes.Scale="Scale"
+Filter.VideoSuperResolution.NVIDIA.SuperRes.Strength="Strength"
+Filter.VideoSuperResolution.NVIDIA.SuperRes.Strength.Weak="Weak"
+Filter.VideoSuperResolution.NVIDIA.SuperRes.Strength.Strong="Strong"
+
 # Source - Mirror
 Source.Mirror="Source Mirror"
 Source.Mirror.Source="Source"

--- a/source/filters/filter-video-superresolution.cpp
+++ b/source/filters/filter-video-superresolution.cpp
@@ -1,0 +1,610 @@
+// Copyright (c) 2020 Michael Fabian Dirks <info@xaymar.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "filter-video-superresolution.hpp"
+#include <algorithm>
+#include "obs/gs/gs-helper.hpp"
+#include "plugin.hpp"
+#include "util/util-logging.hpp"
+
+#ifdef _DEBUG
+#define ST_PREFIX "<%s> "
+#define D_LOG_ERROR(x, ...) P_LOG_ERROR(ST_PREFIX##x, __FUNCTION_SIG__, __VA_ARGS__)
+#define D_LOG_WARNING(x, ...) P_LOG_WARN(ST_PREFIX##x, __FUNCTION_SIG__, __VA_ARGS__)
+#define D_LOG_INFO(x, ...) P_LOG_INFO(ST_PREFIX##x, __FUNCTION_SIG__, __VA_ARGS__)
+#define D_LOG_DEBUG(x, ...) P_LOG_DEBUG(ST_PREFIX##x, __FUNCTION_SIG__, __VA_ARGS__)
+#else
+#define ST_PREFIX "<filter::video_superresolution> "
+#define D_LOG_ERROR(...) P_LOG_ERROR(ST_PREFIX __VA_ARGS__)
+#define D_LOG_WARNING(...) P_LOG_WARN(ST_PREFIX __VA_ARGS__)
+#define D_LOG_INFO(...) P_LOG_INFO(ST_PREFIX __VA_ARGS__)
+#define D_LOG_DEBUG(...) P_LOG_DEBUG(ST_PREFIX __VA_ARGS__)
+#endif
+
+#define ST_I18N "Filter.VideoSuperResolution"
+#define ST_KEY_PROVIDER "Provider"
+#define ST_I18N_PROVIDER ST_I18N "." ST_KEY_PROVIDER
+#define ST_I18N_PROVIDER_NVIDIA_SUPERRES ST_I18N_PROVIDER ".NVIDIAVideoSuperResolution"
+
+#ifdef ENABLE_FILTER_VIDEO_SUPERRESOLUTION_NVIDIA
+#define ST_KEY_NVIDIA_SUPERRES "NVIDIA.SuperRes"
+#define ST_I18N_NVIDIA_SUPERRES ST_I18N "." ST_KEY_NVIDIA_SUPERRES
+#define ST_KEY_NVIDIA_SUPERRES_STRENGTH "NVIDIA.SuperRes.Strength"
+#define ST_I18N_NVIDIA_SUPERRES_STRENGTH ST_I18N "." ST_KEY_NVIDIA_SUPERRES_STRENGTH
+#define ST_I18N_NVIDIA_SUPERRES_STRENGTH_WEAK ST_I18N_NVIDIA_SUPERRES_STRENGTH ".Weak"
+#define ST_I18N_NVIDIA_SUPERRES_STRENGTH_STRONG ST_I18N_NVIDIA_SUPERRES_STRENGTH ".Strong"
+#define ST_KEY_NVIDIA_SUPERRES_SCALE "NVIDIA.SuperRes.Scale"
+#define ST_I18N_NVIDIA_SUPERRES_SCALE ST_I18N "." ST_KEY_NVIDIA_SUPERRES_SCALE
+#endif
+
+using streamfx::filter::video_superresolution::video_superresolution_factory;
+using streamfx::filter::video_superresolution::video_superresolution_instance;
+using streamfx::filter::video_superresolution::video_superresolution_provider;
+
+static constexpr std::string_view HELP_URL =
+	"https://github.com/Xaymar/obs-StreamFX/wiki/Filter-Video-Super-Resolution";
+
+/** Priority of providers for automatic selection if more than one is available.
+ * 
+ */
+static video_superresolution_provider provider_priority[] = {
+	video_superresolution_provider::NVIDIA_VIDEO_SUPERRESOLUTION,
+};
+
+const char* streamfx::filter::video_superresolution::cstring(video_superresolution_provider provider)
+{
+	switch (provider) {
+	case video_superresolution_provider::INVALID:
+		return "N/A";
+	case video_superresolution_provider::AUTOMATIC:
+		return D_TRANSLATE(S_STATE_AUTOMATIC);
+	case video_superresolution_provider::NVIDIA_VIDEO_SUPERRESOLUTION:
+		return D_TRANSLATE(ST_I18N_PROVIDER_NVIDIA_SUPERRES);
+	default:
+		throw std::runtime_error("Missing Conversion Entry");
+	}
+}
+
+std::string streamfx::filter::video_superresolution::string(video_superresolution_provider provider)
+{
+	return cstring(provider);
+}
+
+//------------------------------------------------------------------------------
+// Instance
+//------------------------------------------------------------------------------
+video_superresolution_instance::video_superresolution_instance(obs_data_t* data, obs_source_t* self)
+	: obs::source_instance(data, self),
+
+	  _in_size(1, 1), _out_size(1, 1), _provider_ready(false), _provider(video_superresolution_provider::INVALID),
+	  _provider_lock(), _provider_task(), _input(), _output(), _dirty(false)
+{
+	{
+		::streamfx::obs::gs::context gctx;
+
+		// Create the render target for the input buffering.
+		_input = std::make_shared<::streamfx::obs::gs::rendertarget>(GS_RGBA_UNORM, GS_ZS_NONE);
+		_input->render(1, 1); // Preallocate the RT on the driver and GPU.
+		_output = _input->get_texture();
+	}
+
+	if (data) {
+		load(data);
+	}
+}
+
+video_superresolution_instance::~video_superresolution_instance()
+{
+	// TODO: Make this asynchronous.
+	std::unique_lock<std::mutex> ul(_provider_lock);
+	switch (_provider) {
+#ifdef ENABLE_FILTER_VIDEO_SUPERRESOLUTION_NVIDIA
+	case video_superresolution_provider::NVIDIA_VIDEO_SUPERRESOLUTION:
+		nvvfxsr_unload();
+		break;
+#endif
+	default:
+		break;
+	}
+}
+
+void video_superresolution_instance::load(obs_data_t* data)
+{
+	update(data);
+}
+
+void video_superresolution_instance::migrate(obs_data_t* data, uint64_t version) {}
+
+void video_superresolution_instance::update(obs_data_t* data)
+{
+	// Check if the user changed which Denoising provider we use.
+	video_superresolution_provider provider =
+		static_cast<video_superresolution_provider>(obs_data_get_int(data, ST_KEY_PROVIDER));
+	if (provider == video_superresolution_provider::AUTOMATIC) {
+		for (auto v : provider_priority) {
+			if (video_superresolution_factory::get()->is_provider_available(v)) {
+				provider = v;
+				break;
+			}
+		}
+	}
+
+	// Check if the provider was changed, and if so switch.
+	if (provider != _provider) {
+		switch_provider(provider);
+	}
+
+	if (_provider_ready) {
+		std::unique_lock<std::mutex> ul(_provider_lock);
+
+		switch (_provider) {
+#ifdef ENABLE_FILTER_VIDEO_SUPERRESOLUTION_NVIDIA
+		case video_superresolution_provider::NVIDIA_VIDEO_SUPERRESOLUTION:
+			nvvfxsr_update(data);
+			break;
+#endif
+		default:
+			break;
+		}
+	}
+}
+
+void streamfx::filter::video_superresolution::video_superresolution_instance::properties(obs_properties_t* properties)
+{
+	if (_provider_ready) {
+		std::unique_lock<std::mutex> ul(_provider_lock);
+
+		switch (_provider) {
+#ifdef ENABLE_FILTER_VIDEO_SUPERRESOLUTION_NVIDIA
+		case video_superresolution_provider::NVIDIA_VIDEO_SUPERRESOLUTION:
+			nvvfxsr_properties(properties);
+			break;
+#endif
+		default:
+			break;
+		}
+	}
+}
+
+uint32_t streamfx::filter::video_superresolution::video_superresolution_instance::get_width()
+{
+	return std::max<uint32_t>(_out_size.first, 1);
+}
+
+uint32_t streamfx::filter::video_superresolution::video_superresolution_instance::get_height()
+{
+	return std::max<uint32_t>(_out_size.second, 1);
+}
+
+void video_superresolution_instance::video_tick(float_t time)
+{
+	auto target = obs_filter_get_target(_self);
+	auto width  = obs_source_get_base_width(target);
+	auto height = obs_source_get_base_height(target);
+	_in_size    = {width, height};
+	_out_size   = _in_size;
+
+	// Allow the provider to restrict the size.
+	if (target && _provider_ready) {
+		std::unique_lock<std::mutex> ul(_provider_lock);
+
+		switch (_provider) {
+#ifdef ENABLE_FILTER_VIDEO_SUPERRESOLUTION_NVIDIA
+		case video_superresolution_provider::NVIDIA_VIDEO_SUPERRESOLUTION:
+			nvvfxsr_size();
+			break;
+#endif
+		default:
+			break;
+		}
+	}
+
+	_dirty = true;
+}
+
+void video_superresolution_instance::video_render(gs_effect_t* effect)
+{
+	auto parent = obs_filter_get_parent(_self);
+	auto target = obs_filter_get_target(_self);
+	auto width  = obs_source_get_base_width(target);
+	auto height = obs_source_get_base_height(target);
+	vec4 blank  = vec4{0, 0, 0, 0};
+
+	// Ensure we have the bare minimum of valid information.
+	target = target ? target : parent;
+	effect = effect ? effect : obs_get_base_effect(OBS_EFFECT_DEFAULT);
+
+	// Skip the filter if:
+	// - The Provider isn't ready yet.
+	// - We don't have a target.
+	// - The width/height of the next filter in the chain is empty.
+	if (!_provider_ready || !target || (width == 0) || (height == 0)) {
+		obs_source_skip_video_filter(_self);
+		return;
+	}
+
+#ifdef ENABLE_PROFILING
+	::streamfx::obs::gs::debug_marker profiler0{::streamfx::obs::gs::debug_color_source,
+												"StreamFX Video Super-Resolution"};
+	::streamfx::obs::gs::debug_marker profiler0_0{::streamfx::obs::gs::debug_color_gray, "'%s' on '%s'",
+												  obs_source_get_name(_self), obs_source_get_name(parent)};
+#endif
+
+	if (_dirty) {
+		// Lock the provider from being changed.
+		std::unique_lock<std::mutex> ul(_provider_lock);
+
+		{ // Capture the incoming frame.
+#ifdef ENABLE_PROFILING
+			::streamfx::obs::gs::debug_marker profiler1{::streamfx::obs::gs::debug_color_capture, "Capture"};
+#endif
+			if (obs_source_process_filter_begin(_self, GS_RGBA, OBS_ALLOW_DIRECT_RENDERING)) {
+				auto op = _input->render(_in_size.first, _in_size.second);
+
+				// Matrix
+				gs_matrix_push();
+				gs_ortho(0., 1., 0., 1., 0., 1.);
+
+				// Clear the buffer
+				gs_clear(GS_CLEAR_COLOR | GS_CLEAR_DEPTH, &blank, 0, 0);
+
+				// Set GPU state
+				gs_blend_state_push();
+				gs_enable_color(true, true, true, true);
+				gs_enable_blending(false);
+				gs_enable_depth_test(false);
+				gs_enable_stencil_test(false);
+				gs_set_cull_mode(GS_NEITHER);
+
+				// Render
+#ifdef ENABLE_PROFILING
+				::streamfx::obs::gs::debug_marker profiler2{::streamfx::obs::gs::debug_color_capture, "Storage"};
+#endif
+				obs_source_process_filter_end(_self, obs_get_base_effect(OBS_EFFECT_DEFAULT), 1, 1);
+
+				// Reset GPU state
+				gs_blend_state_pop();
+				gs_matrix_pop();
+			} else {
+				obs_source_skip_video_filter(_self);
+				return;
+			}
+		}
+
+		try { // Process the captured input with the provider.
+#ifdef ENABLE_PROFILING
+			::streamfx::obs::gs::debug_marker profiler1{::streamfx::obs::gs::debug_color_convert, "Process"};
+#endif
+			switch (_provider) {
+#ifdef ENABLE_FILTER_VIDEO_SUPERRESOLUTION_NVIDIA
+			case video_superresolution_provider::NVIDIA_VIDEO_SUPERRESOLUTION:
+				nvvfxsr_process();
+				break;
+#endif
+			default:
+				_output.reset();
+				break;
+			}
+		} catch (...) {
+			obs_source_skip_video_filter(_self);
+			return;
+		}
+
+		if (!_output) {
+			D_LOG_ERROR("Provider '%s' did not return a result.", cstring(_provider));
+			obs_source_skip_video_filter(_self);
+			return;
+		}
+
+		_dirty = false;
+	}
+
+	{ // Draw the result for the next filter to use.
+#ifdef ENABLE_PROFILING
+		::streamfx::obs::gs::debug_marker profiler1{::streamfx::obs::gs::debug_color_render, "Render"};
+#endif
+		gs_effect_set_texture(gs_effect_get_param_by_name(effect, "image"), _output->get_object());
+		while (gs_effect_loop(effect, "Draw")) {
+			gs_draw_sprite(nullptr, 0, _out_size.first, _out_size.second);
+		}
+	}
+}
+
+struct switch_provider_data_t {
+	video_superresolution_provider provider;
+};
+
+void streamfx::filter::video_superresolution::video_superresolution_instance::switch_provider(
+	video_superresolution_provider provider)
+{
+	std::unique_lock<std::mutex> ul(_provider_lock);
+
+	// Safeguard against calls made from unlocked memory.
+	if (provider == _provider) {
+		return;
+	}
+
+	// This doesn't work correctly.
+	// - Need to allow multiple switches at once because OBS is weird.
+	// - Doesn't guarantee that the task is properly killed off.
+
+	// Log information.
+	D_LOG_INFO("Instance '%s' is switching provider from '%s' to '%s'.", obs_source_get_name(_self), cstring(_provider),
+			   cstring(provider));
+
+	// 1.If there is an existing task, attempt to cancel it.
+	if (_provider_task) {
+		streamfx::threadpool()->pop(_provider_task);
+	}
+
+	// 2. Build data to pass into the task.
+	auto spd      = std::make_shared<switch_provider_data_t>();
+	spd->provider = _provider;
+	_provider     = provider;
+
+	// 3. Then spawn a new task to switch provider.
+	_provider_task = streamfx::threadpool()->push(
+		std::bind(&video_superresolution_instance::task_switch_provider, this, std::placeholders::_1), spd);
+}
+
+void streamfx::filter::video_superresolution::video_superresolution_instance::task_switch_provider(
+	util::threadpool_data_t data)
+{
+	std::shared_ptr<switch_provider_data_t> spd = std::static_pointer_cast<switch_provider_data_t>(data);
+
+	// 1. Mark the provider as no longer ready.
+	_provider_ready = false;
+
+	// 2. Lock the provider from being used.
+	std::unique_lock<std::mutex> ul(_provider_lock);
+
+	try {
+		// 3. Unload the previous provider.
+		switch (spd->provider) {
+#ifdef ENABLE_FILTER_VIDEO_SUPERRESOLUTION_NVIDIA
+		case video_superresolution_provider::NVIDIA_VIDEO_SUPERRESOLUTION:
+			nvvfxsr_unload();
+			break;
+#endif
+		default:
+			break;
+		}
+
+		// 4. Load the new provider.
+		switch (_provider) {
+#ifdef ENABLE_FILTER_VIDEO_SUPERRESOLUTION_NVIDIA
+		case video_superresolution_provider::NVIDIA_VIDEO_SUPERRESOLUTION:
+			nvvfxsr_load();
+			{
+				auto data = obs_source_get_settings(_self);
+				nvvfxsr_update(data);
+				obs_data_release(data);
+			}
+			break;
+#endif
+		default:
+			break;
+		}
+
+		// Log information.
+		D_LOG_INFO("Instance '%s' switched provider from '%s' to '%s'.", obs_source_get_name(_self),
+				   cstring(spd->provider), cstring(_provider));
+
+		// 5. Set the new provider as valid.
+		_provider_ready = true;
+	} catch (std::exception const& ex) {
+		// Log information.
+		D_LOG_ERROR("Instance '%s' failed switching provider with error: %s", obs_source_get_name(_self), ex.what());
+	}
+}
+
+#ifdef ENABLE_FILTER_VIDEO_SUPERRESOLUTION_NVIDIA
+void streamfx::filter::video_superresolution::video_superresolution_instance::nvvfxsr_load()
+{
+	_nvidia_fx = std::make_shared<::streamfx::nvidia::vfx::superresolution>();
+}
+
+void streamfx::filter::video_superresolution::video_superresolution_instance::nvvfxsr_unload()
+{
+	_nvidia_fx.reset();
+}
+
+void streamfx::filter::video_superresolution::video_superresolution_instance::nvvfxsr_size()
+{
+	if (!_nvidia_fx) {
+		return;
+	}
+
+	auto in_size = _in_size;
+	_nvidia_fx->size(in_size, _in_size, _out_size);
+}
+
+void streamfx::filter::video_superresolution::video_superresolution_instance::nvvfxsr_process()
+{
+	if (!_nvidia_fx) {
+		_output = _input->get_texture();
+		return;
+	}
+
+	_output = _nvidia_fx->process(_input->get_texture());
+}
+
+void streamfx::filter::video_superresolution::video_superresolution_instance::nvvfxsr_properties(
+	obs_properties_t* props)
+{
+	obs_properties_t* grp = obs_properties_create();
+	obs_properties_add_group(props, ST_KEY_NVIDIA_SUPERRES, D_TRANSLATE(ST_I18N_NVIDIA_SUPERRES), OBS_GROUP_NORMAL,
+							 grp);
+
+	{
+		auto p =
+			obs_properties_add_list(grp, ST_KEY_NVIDIA_SUPERRES_STRENGTH, D_TRANSLATE(ST_I18N_NVIDIA_SUPERRES_STRENGTH),
+									OBS_COMBO_TYPE_LIST, OBS_COMBO_FORMAT_INT);
+		obs_property_list_add_int(p, D_TRANSLATE(ST_I18N_NVIDIA_SUPERRES_STRENGTH_WEAK), 0);
+		obs_property_list_add_int(p, D_TRANSLATE(ST_I18N_NVIDIA_SUPERRES_STRENGTH_STRONG), 1);
+	}
+
+	{
+		auto p = obs_properties_add_float_slider(grp, ST_KEY_NVIDIA_SUPERRES_SCALE,
+												 D_TRANSLATE(ST_I18N_NVIDIA_SUPERRES_SCALE), 100.00, 400.00, .01);
+		obs_property_float_set_suffix(p, " %");
+	}
+}
+
+void streamfx::filter::video_superresolution::video_superresolution_instance::nvvfxsr_update(obs_data_t* data)
+{
+	if (!_nvidia_fx)
+		return;
+
+	_nvidia_fx->set_strength(
+		static_cast<float>(obs_data_get_int(data, ST_KEY_NVIDIA_SUPERRES_STRENGTH) == 0 ? 0. : 1.));
+	_nvidia_fx->set_scale(static_cast<float>(obs_data_get_double(data, ST_KEY_NVIDIA_SUPERRES_SCALE) / 100.));
+}
+
+#endif
+
+//------------------------------------------------------------------------------
+// Factory
+//------------------------------------------------------------------------------
+video_superresolution_factory::~video_superresolution_factory() {}
+
+video_superresolution_factory::video_superresolution_factory()
+{
+	bool any_available = false;
+
+	// 1. Try and load any configured providers.
+#ifdef ENABLE_FILTER_VIDEO_SUPERRESOLUTION_NVIDIA
+	try {
+		// Load CVImage and Video Effects SDK.
+		_nvcuda           = ::streamfx::nvidia::cuda::obs::get();
+		_nvcvi            = ::streamfx::nvidia::cv::cv::get();
+		_nvvfx            = ::streamfx::nvidia::vfx::vfx::get();
+		_nvidia_available = true;
+		any_available |= _nvidia_available;
+	} catch (const std::exception& ex) {
+		_nvidia_available = false;
+		_nvvfx.reset();
+		_nvcvi.reset();
+		_nvcuda.reset();
+		D_LOG_WARNING("Failed to make NVIDIA Super-Resolution available due to error: %s", ex.what());
+	}
+#endif
+
+	// 2. Check if any of them managed to load at all.
+	if (!any_available) {
+		D_LOG_ERROR("All supported Super-Resolution providers failed to initialize, disabling effect.", 0);
+		return;
+	}
+
+	// 3. In any other case, register the filter!
+	_info.id           = S_PREFIX "filter-video-superresolution";
+	_info.type         = OBS_SOURCE_TYPE_FILTER;
+	_info.output_flags = OBS_SOURCE_VIDEO /*| OBS_SOURCE_SRGB*/;
+
+	set_resolution_enabled(true);
+	finish_setup();
+}
+
+const char* video_superresolution_factory::get_name()
+{
+	return D_TRANSLATE(ST_I18N);
+}
+
+void video_superresolution_factory::get_defaults2(obs_data_t* data)
+{
+	obs_data_set_default_int(data, ST_KEY_PROVIDER, static_cast<int64_t>(video_superresolution_provider::AUTOMATIC));
+
+#ifdef ENABLE_FILTER_VIDEO_SUPERRESOLUTION_NVIDIA
+	obs_data_set_default_double(data, ST_KEY_NVIDIA_SUPERRES_SCALE, 150.);
+	obs_data_set_default_double(data, ST_KEY_NVIDIA_SUPERRES_STRENGTH, 0.);
+#endif
+}
+
+obs_properties_t* video_superresolution_factory::get_properties2(video_superresolution_instance* data)
+{
+	obs_properties_t* pr = obs_properties_create();
+
+#ifdef ENABLE_FRONTEND
+	{
+		obs_properties_add_button2(pr, S_MANUAL_OPEN, D_TRANSLATE(S_MANUAL_OPEN),
+								   video_superresolution_factory::on_manual_open, nullptr);
+	}
+#endif
+
+	if (data) {
+		data->properties(pr);
+	}
+
+	{ // Advanced Settings
+		auto grp = obs_properties_create();
+		obs_properties_add_group(pr, S_ADVANCED, D_TRANSLATE(S_ADVANCED), OBS_GROUP_NORMAL, grp);
+
+		{
+			auto p = obs_properties_add_list(grp, ST_KEY_PROVIDER, D_TRANSLATE(ST_I18N_PROVIDER), OBS_COMBO_TYPE_LIST,
+											 OBS_COMBO_FORMAT_INT);
+			obs_property_list_add_int(p, D_TRANSLATE(S_STATE_AUTOMATIC),
+									  static_cast<int64_t>(video_superresolution_provider::AUTOMATIC));
+			obs_property_list_add_int(
+				p, D_TRANSLATE(ST_I18N_PROVIDER_NVIDIA_SUPERRES),
+				static_cast<int64_t>(video_superresolution_provider::NVIDIA_VIDEO_SUPERRESOLUTION));
+		}
+	}
+
+	return pr;
+}
+
+#ifdef ENABLE_FRONTEND
+bool video_superresolution_factory::on_manual_open(obs_properties_t* props, obs_property_t* property, void* data)
+{
+	streamfx::open_url(HELP_URL);
+	return false;
+}
+#endif
+
+bool streamfx::filter::video_superresolution::video_superresolution_factory::is_provider_available(
+	video_superresolution_provider provider)
+{
+	switch (provider) {
+#ifdef ENABLE_FILTER_VIDEO_SUPERRESOLUTION_NVIDIA
+	case video_superresolution_provider::NVIDIA_VIDEO_SUPERRESOLUTION:
+		return _nvidia_available;
+#endif
+	default:
+		return false;
+	}
+}
+
+std::shared_ptr<video_superresolution_factory> _video_denoising_factory_instance = nullptr;
+
+void video_superresolution_factory::initialize()
+{
+	if (!_video_denoising_factory_instance)
+		_video_denoising_factory_instance = std::make_shared<video_superresolution_factory>();
+}
+
+void video_superresolution_factory::finalize()
+{
+	_video_denoising_factory_instance.reset();
+}
+
+std::shared_ptr<video_superresolution_factory> video_superresolution_factory::get()
+{
+	return _video_denoising_factory_instance;
+}

--- a/source/filters/filter-video-superresolution.hpp
+++ b/source/filters/filter-video-superresolution.hpp
@@ -1,0 +1,124 @@
+// Copyright (c) 2020 Michael Fabian Dirks <info@xaymar.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+#include <atomic>
+#include <memory>
+#include <mutex>
+#include "obs/gs/gs-rendertarget.hpp"
+#include "obs/gs/gs-texture.hpp"
+#include "obs/obs-source-factory.hpp"
+#include "plugin.hpp"
+#include "util/util-threadpool.hpp"
+
+#ifdef ENABLE_FILTER_VIDEO_SUPERRESOLUTION_NVIDIA
+#include "nvidia/vfx/nvidia-vfx-superresolution.hpp"
+#endif
+
+namespace streamfx::filter::video_superresolution {
+	enum class video_superresolution_provider {
+		INVALID                      = -1,
+		AUTOMATIC                    = 0,
+		NVIDIA_VIDEO_SUPERRESOLUTION = 1,
+	};
+
+	const char* cstring(video_superresolution_provider provider);
+
+	std::string string(video_superresolution_provider provider);
+
+	class video_superresolution_instance : public ::streamfx::obs::source_instance {
+		std::pair<uint32_t, uint32_t> _in_size;
+		std::pair<uint32_t, uint32_t> _out_size;
+
+		std::atomic<bool>                           _provider_ready;
+		std::atomic<video_superresolution_provider> _provider;
+		std::mutex                                  _provider_lock;
+		std::shared_ptr<util::threadpool::task>     _provider_task;
+
+		std::shared_ptr<::streamfx::obs::gs::rendertarget> _input;
+		std::shared_ptr<::streamfx::obs::gs::texture>      _output;
+		bool                                               _dirty;
+
+#ifdef ENABLE_FILTER_VIDEO_SUPERRESOLUTION_NVIDIA
+		std::shared_ptr<::streamfx::nvidia::vfx::superresolution> _nvidia_fx;
+#endif
+
+		public:
+		video_superresolution_instance(obs_data_t* data, obs_source_t* self);
+		~video_superresolution_instance() override;
+
+		void load(obs_data_t* data) override;
+		void migrate(obs_data_t* data, uint64_t version) override;
+		void update(obs_data_t* data) override;
+		void properties(obs_properties_t* properties);
+
+		uint32_t get_width() override;
+		uint32_t get_height() override;
+
+		void video_tick(float_t time) override;
+		void video_render(gs_effect_t* effect) override;
+
+		private:
+		void switch_provider(video_superresolution_provider provider);
+		void task_switch_provider(util::threadpool_data_t data);
+
+#ifdef ENABLE_FILTER_VIDEO_SUPERRESOLUTION_NVIDIA
+		void nvvfxsr_load();
+		void nvvfxsr_unload();
+		void nvvfxsr_size();
+		void nvvfxsr_process();
+		void nvvfxsr_properties(obs_properties_t* props);
+		void nvvfxsr_update(obs_data_t* data);
+#endif
+	};
+
+	class video_superresolution_factory
+		: public ::streamfx::obs::source_factory<
+			  ::streamfx::filter::video_superresolution::video_superresolution_factory,
+			  ::streamfx::filter::video_superresolution::video_superresolution_instance> {
+#ifdef ENABLE_FILTER_VIDEO_SUPERRESOLUTION_NVIDIA
+		bool                                           _nvidia_available;
+		std::shared_ptr<::streamfx::nvidia::cuda::obs> _nvcuda;
+		std::shared_ptr<::streamfx::nvidia::cv::cv>    _nvcvi;
+		std::shared_ptr<::streamfx::nvidia::vfx::vfx>  _nvvfx;
+#endif
+
+		public:
+		virtual ~video_superresolution_factory();
+		video_superresolution_factory();
+
+		virtual const char* get_name() override;
+
+		virtual void              get_defaults2(obs_data_t* data) override;
+		virtual obs_properties_t* get_properties2(video_superresolution_instance* data) override;
+
+#ifdef ENABLE_FRONTEND
+		static bool on_manual_open(obs_properties_t* props, obs_property_t* property, void* data);
+#endif
+
+		bool is_provider_available(video_superresolution_provider);
+
+		public: // Singleton
+		static void                                                                                      initialize();
+		static void                                                                                      finalize();
+		static std::shared_ptr<::streamfx::filter::video_superresolution::video_superresolution_factory> get();
+	};
+
+} // namespace streamfx::filter::video_superresolution

--- a/source/nvidia/cuda/nvidia-cuda-context.cpp
+++ b/source/nvidia/cuda/nvidia-cuda-context.cpp
@@ -150,7 +150,7 @@ void streamfx::nvidia::cuda::context::pop()
 
 void streamfx::nvidia::cuda::context::synchronize()
 {
-	D_LOG_DEBUG("Synchronizing... (Addr: 0x%" PRIuPTR ")", this);
+	//D_LOG_DEBUG("Synchronizing... (Addr: 0x%" PRIuPTR ")", this);
 
 #ifdef ENABLE_STACK_CHECKS
 	::streamfx::nvidia::cuda::context_t ctx;

--- a/source/nvidia/cuda/nvidia-cuda-stream.cpp
+++ b/source/nvidia/cuda/nvidia-cuda-stream.cpp
@@ -68,7 +68,7 @@ streamfx::nvidia::cuda::stream::stream(::streamfx::nvidia::cuda::stream_flags fl
 
 void streamfx::nvidia::cuda::stream::synchronize()
 {
-	D_LOG_DEBUG("Synchronizing... (Addr: 0x%" PRIuPTR ")", this);
+	//D_LOG_DEBUG("Synchronizing... (Addr: 0x%" PRIuPTR ")", this);
 	if (auto res = _cuda->cuStreamSynchronize(_stream); res != ::streamfx::nvidia::cuda::result::SUCCESS) {
 		throw ::streamfx::nvidia::cuda::cuda_error(res);
 	}

--- a/source/nvidia/cuda/nvidia-cuda.cpp
+++ b/source/nvidia/cuda/nvidia-cuda.cpp
@@ -89,7 +89,7 @@ streamfx::nvidia::cuda::cuda::cuda() : _library()
 {
 	int32_t cuda_version = 0;
 
-	D_LOG_DEBUG("Initialization... (Addr: 0x%" PRIuPTR ")", this);
+	D_LOG_DEBUG("Initializing... (Addr: 0x%" PRIuPTR ")", this);
 
 	_library = streamfx::util::library::load(std::string_view(ST_CUDA_NAME));
 

--- a/source/nvidia/cv/nvidia-cv-image.cpp
+++ b/source/nvidia/cv/nvidia-cv-image.cpp
@@ -1,0 +1,98 @@
+// Copyright (c) 2020 Michael Fabian Dirks <info@xaymar.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+// NVIDIA CVImage is part of:
+// - NVIDIA Video Effects SDK
+// - NVIDIA Augmented Reality SDK
+
+#include "nvidia-cv-image.hpp"
+#include "nvidia/cuda/nvidia-cuda-obs.hpp"
+#include "obs/gs/gs-helper.hpp"
+
+#ifdef _DEBUG
+#define ST_PREFIX "<%s> "
+#define D_LOG_ERROR(x, ...) P_LOG_ERROR(ST_PREFIX##x, __FUNCTION_SIG__, __VA_ARGS__)
+#define D_LOG_WARNING(x, ...) P_LOG_WARN(ST_PREFIX##x, __FUNCTION_SIG__, __VA_ARGS__)
+#define D_LOG_INFO(x, ...) P_LOG_INFO(ST_PREFIX##x, __FUNCTION_SIG__, __VA_ARGS__)
+#define D_LOG_DEBUG(x, ...) P_LOG_DEBUG(ST_PREFIX##x, __FUNCTION_SIG__, __VA_ARGS__)
+#else
+#define ST_PREFIX "<nvidia::cv::image> "
+#define D_LOG_ERROR(...) P_LOG_ERROR(ST_PREFIX __VA_ARGS__)
+#define D_LOG_WARNING(...) P_LOG_WARN(ST_PREFIX __VA_ARGS__)
+#define D_LOG_INFO(...) P_LOG_INFO(ST_PREFIX __VA_ARGS__)
+#define D_LOG_DEBUG(...) P_LOG_DEBUG(ST_PREFIX __VA_ARGS__)
+#endif
+
+using ::streamfx::nvidia::cv::image;
+using ::streamfx::nvidia::cv::result;
+
+image::~image()
+{
+	auto gctx = ::streamfx::obs::gs::context();
+	auto cctx = ::streamfx::nvidia::cuda::obs::get()->get_context()->enter();
+
+	_cv->NvCVImage_Dealloc(&_image);
+}
+
+image::image() : _cv(::streamfx::nvidia::cv::cv::get()), _image()
+{
+	// Forcefully clear the image storage.
+	memset(&_image, sizeof(_image), 0);
+}
+
+image::image(uint32_t width, uint32_t height, pixel_format pix_fmt, component_type cmp_type,
+			 component_layout cmp_layout, memory_location location, uint32_t alignment)
+	: image()
+{
+	auto gctx = ::streamfx::obs::gs::context();
+	auto cctx = ::streamfx::nvidia::cuda::obs::get()->get_context()->enter();
+
+	if (auto res = _cv->NvCVImage_Alloc(&_image, width, height, pix_fmt, cmp_type, static_cast<uint32_t>(cmp_layout),
+										static_cast<uint32_t>(location), alignment);
+		res != result::SUCCESS) {
+		throw std::runtime_error(_cv->NvCV_GetErrorStringFromCode(res));
+	}
+}
+
+void streamfx::nvidia::cv::image::reallocate(uint32_t width, uint32_t height, pixel_format pix_fmt,
+											 component_type cmp_type, component_layout cmp_layout,
+											 memory_location location, uint32_t alignment)
+{
+	auto gctx = ::streamfx::obs::gs::context();
+	auto cctx = ::streamfx::nvidia::cuda::obs::get()->get_context()->enter();
+
+	if (auto res = _cv->NvCVImage_Realloc(&_image, width, height, pix_fmt, cmp_type, static_cast<uint32_t>(cmp_layout),
+										  static_cast<uint32_t>(location), alignment);
+		res != result::SUCCESS) {
+		throw std::runtime_error(_cv->NvCV_GetErrorStringFromCode(res));
+	}
+}
+
+void streamfx::nvidia::cv::image::resize(uint32_t width, uint32_t height)
+{
+	// TODO: Is pixel_bytes correct?
+	reallocate(width, height, _image.pxl_format, _image.comp_type, static_cast<component_layout>(_image.comp_layout),
+			   static_cast<memory_location>(_image.mem_location), _image.pixel_bytes);
+}
+
+streamfx::nvidia::cv::image_t* streamfx::nvidia::cv::image::get_image()
+{
+	return &_image;
+}

--- a/source/nvidia/cv/nvidia-cv-image.hpp
+++ b/source/nvidia/cv/nvidia-cv-image.hpp
@@ -1,0 +1,54 @@
+// Copyright (c) 2021 Michael Fabian Dirks <info@xaymar.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+#include <cinttypes>
+#include "nvidia/cv/nvidia-cv.hpp"
+
+namespace streamfx::nvidia::cv {
+	using ::streamfx::nvidia::cv::component_layout;
+	using ::streamfx::nvidia::cv::component_type;
+	using ::streamfx::nvidia::cv::memory_location;
+	using ::streamfx::nvidia::cv::pixel_format;
+
+	class image {
+		protected:
+		std::shared_ptr<::streamfx::nvidia::cv::cv> _cv;
+		image_t                                     _image;
+
+		public:
+		virtual ~image();
+
+		protected:
+		image();
+
+		public:
+		image(uint32_t width, uint32_t height, pixel_format pix_fmt, component_type cmp_type,
+			  component_layout cmp_layout, memory_location location, uint32_t alignment);
+
+		virtual void reallocate(uint32_t width, uint32_t height, pixel_format pix_fmt, component_type cmp_type,
+								component_layout cmp_layout, memory_location location, uint32_t alignment);
+
+		virtual void resize(uint32_t width, uint32_t height);
+
+		virtual ::streamfx::nvidia::cv::image_t* get_image();
+	};
+
+} // namespace streamfx::nvidia::cv

--- a/source/nvidia/cv/nvidia-cv-texture.cpp
+++ b/source/nvidia/cv/nvidia-cv-texture.cpp
@@ -1,0 +1,127 @@
+// Copyright (c) 2020 Michael Fabian Dirks <info@xaymar.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+// NVIDIA CVImage is part of:
+// - NVIDIA Video Effects SDK
+// - NVIDIA Augmented Reality SDK
+
+#include "nvidia-cv-texture.hpp"
+#include "nvidia/cuda/nvidia-cuda-obs.hpp"
+#include "obs/gs/gs-helper.hpp"
+#include "util/util-logging.hpp"
+
+#ifdef _DEBUG
+#define ST_PREFIX "<%s> "
+#define D_LOG_ERROR(x, ...) P_LOG_ERROR(ST_PREFIX##x, __FUNCTION_SIG__, __VA_ARGS__)
+#define D_LOG_WARNING(x, ...) P_LOG_WARN(ST_PREFIX##x, __FUNCTION_SIG__, __VA_ARGS__)
+#define D_LOG_INFO(x, ...) P_LOG_INFO(ST_PREFIX##x, __FUNCTION_SIG__, __VA_ARGS__)
+#define D_LOG_DEBUG(x, ...) P_LOG_DEBUG(ST_PREFIX##x, __FUNCTION_SIG__, __VA_ARGS__)
+#else
+#define ST_PREFIX "<nvidia::cv::texture> "
+#define D_LOG_ERROR(...) P_LOG_ERROR(ST_PREFIX __VA_ARGS__)
+#define D_LOG_WARNING(...) P_LOG_WARN(ST_PREFIX __VA_ARGS__)
+#define D_LOG_INFO(...) P_LOG_INFO(ST_PREFIX __VA_ARGS__)
+#define D_LOG_DEBUG(...) P_LOG_DEBUG(ST_PREFIX __VA_ARGS__)
+#endif
+
+using ::streamfx::nvidia::cv::component_layout;
+using ::streamfx::nvidia::cv::component_type;
+using ::streamfx::nvidia::cv::pixel_format;
+using ::streamfx::nvidia::cv::result;
+using ::streamfx::nvidia::cv::texture;
+
+texture::~texture()
+{
+	auto gctx = ::streamfx::obs::gs::context();
+	auto cctx = ::streamfx::nvidia::cuda::obs::get()->get_context()->enter();
+
+	free();
+	_texture.reset();
+}
+
+texture::texture(uint32_t width, uint32_t height, gs_color_format pix_fmt)
+{
+	auto gctx = ::streamfx::obs::gs::context();
+	auto cctx = ::streamfx::nvidia::cuda::obs::get()->get_context()->enter();
+
+	// Allocate a new Texture
+	_texture = std::make_shared<::streamfx::obs::gs::texture>(width, height, pix_fmt, 1, nullptr,
+															  ::streamfx::obs::gs::texture::flags::None);
+	alloc();
+}
+
+void texture::resize(uint32_t width, uint32_t height)
+{
+	auto gctx = ::streamfx::obs::gs::context();
+	auto cctx = ::streamfx::nvidia::cuda::obs::get()->get_context()->enter();
+
+	D_LOG_DEBUG("Resizing object 0x%" PRIxPTR " to %" PRIu32 "x%" PRIu32 "...", this, width, height);
+
+	// Allocate a new Texture
+	free();
+	_texture = std::make_shared<::streamfx::obs::gs::texture>(width, height, _texture->get_color_format(), 1, nullptr,
+															  ::streamfx::obs::gs::texture::flags::None);
+	alloc();
+}
+
+std::shared_ptr<::streamfx::obs::gs::texture> texture::get_texture()
+{
+	return _texture;
+}
+
+void streamfx::nvidia::cv::texture::alloc()
+{
+	auto gctx  = ::streamfx::obs::gs::context();
+	auto cctx  = ::streamfx::nvidia::cuda::obs::get()->get_context()->enter();
+	auto nvobs = ::streamfx::nvidia::cuda::obs::get();
+
+	// Allocate any relevant CV buffers and Map it.
+	if (auto res = _cv->NvCVImage_InitFromD3D11Texture(
+			&_image, reinterpret_cast<ID3D11Texture2D*>(gs_texture_get_obj(_texture->get_object())));
+		res != result::SUCCESS) {
+		D_LOG_ERROR("Object 0x%" PRIxPTR " failed NvCVImage_InitFromD3D11Texture call with error: %s", this,
+					_cv->NvCV_GetErrorStringFromCode(res));
+		throw std::runtime_error("NvCVImage_InitFromD3D11Texture");
+	}
+	if (auto res = _cv->NvCVImage_MapResource(&_image, nvobs->get_stream()->get()); res != result::SUCCESS) {
+		D_LOG_ERROR("Object 0x%" PRIxPTR " failed NvCVImage_MapResource call with error: %s", this,
+					_cv->NvCV_GetErrorStringFromCode(res));
+		throw std::runtime_error("NvCVImage_MapResource");
+	}
+}
+
+void streamfx::nvidia::cv::texture::free()
+{
+	auto gctx  = ::streamfx::obs::gs::context();
+	auto cctx  = ::streamfx::nvidia::cuda::obs::get()->get_context()->enter();
+	auto nvobs = ::streamfx::nvidia::cuda::obs::get();
+
+	// Unmap and deallocate any relevant CV buffers.
+	if (auto res = _cv->NvCVImage_UnmapResource(&_image, nvobs->get_stream()->get()); res != result::SUCCESS) {
+		D_LOG_ERROR("Object 0x%" PRIxPTR " failed NvCVImage_UnmapResource call with error: %s", this,
+					_cv->NvCV_GetErrorStringFromCode(res));
+		throw std::runtime_error("NvCVImage_UnmapResource");
+	}
+	if (auto res = _cv->NvCVImage_Dealloc(&_image); res != result::SUCCESS) {
+		D_LOG_ERROR("Object 0x%" PRIxPTR " failed NvCVImage_Dealloc call with error: %s", this,
+					_cv->NvCV_GetErrorStringFromCode(res));
+		throw std::runtime_error("NvCVImage_Dealloc");
+	}
+}

--- a/source/nvidia/cv/nvidia-cv-texture.hpp
+++ b/source/nvidia/cv/nvidia-cv-texture.hpp
@@ -1,0 +1,49 @@
+// Copyright (c) 2021 Michael Fabian Dirks <info@xaymar.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+#include <cinttypes>
+#include "nvidia/cv/nvidia-cv-image.hpp"
+#include "obs/gs/gs-texture.hpp"
+
+namespace streamfx::nvidia::cv {
+	using ::streamfx::nvidia::cv::component_layout;
+	using ::streamfx::nvidia::cv::component_type;
+	using ::streamfx::nvidia::cv::image;
+	using ::streamfx::nvidia::cv::memory_location;
+	using ::streamfx::nvidia::cv::pixel_format;
+
+	class texture : public image {
+		std::shared_ptr<::streamfx::obs::gs::texture> _texture;
+
+		public:
+		~texture() override;
+		texture(uint32_t width, uint32_t height, gs_color_format pix_fmt);
+
+		void resize(uint32_t width, uint32_t height) override;
+
+		std::shared_ptr<::streamfx::obs::gs::texture> get_texture();
+
+		private:
+		void alloc();
+		void free();
+	};
+
+} // namespace streamfx::nvidia::cv

--- a/source/nvidia/cv/nvidia-cv.cpp
+++ b/source/nvidia/cv/nvidia-cv.cpp
@@ -1,0 +1,224 @@
+// Copyright (c) 2020 Michael Fabian Dirks <info@xaymar.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+// NVIDIA CVImage is part of:
+// - NVIDIA Video Effects SDK
+// - NVIDIA Augmented Reality SDK
+
+#include "nvidia-cv.hpp"
+#include <filesystem>
+#include <mutex>
+#include "nvidia/cuda/nvidia-cuda-obs.hpp"
+#include "obs/gs/gs-helper.hpp"
+#include "util/util-logging.hpp"
+#include "util/util-platform.hpp"
+
+#ifdef _DEBUG
+#define ST_PREFIX "<%s> "
+#define D_LOG_ERROR(x, ...) P_LOG_ERROR(ST_PREFIX##x, __FUNCTION_SIG__, __VA_ARGS__)
+#define D_LOG_WARNING(x, ...) P_LOG_WARN(ST_PREFIX##x, __FUNCTION_SIG__, __VA_ARGS__)
+#define D_LOG_INFO(x, ...) P_LOG_INFO(ST_PREFIX##x, __FUNCTION_SIG__, __VA_ARGS__)
+#define D_LOG_DEBUG(x, ...) P_LOG_DEBUG(ST_PREFIX##x, __FUNCTION_SIG__, __VA_ARGS__)
+#else
+#define ST_PREFIX "<nvidia::cv::cv> "
+#define D_LOG_ERROR(...) P_LOG_ERROR(ST_PREFIX __VA_ARGS__)
+#define D_LOG_WARNING(...) P_LOG_WARN(ST_PREFIX __VA_ARGS__)
+#define D_LOG_INFO(...) P_LOG_INFO(ST_PREFIX __VA_ARGS__)
+#define D_LOG_DEBUG(...) P_LOG_DEBUG(ST_PREFIX __VA_ARGS__)
+#endif
+
+#if defined(WIN32)
+#include <KnownFolders.h>
+#include <ShlObj.h>
+#include <Windows.h>
+
+#define LIB_NAME "NVCVImage.dll"
+#else
+#define LIB_NAME "libNVCVImage.so"
+#endif
+
+#define ST_ENV_NVIDIA_AR_SDK_PATH L"NV_AR_SDK_PATH"
+#define ST_ENV_NVIDIA_VIDEO_EFFECTS_SDK_PATH L"NV_VIDEO_EFFECTS_PATH"
+
+#define NVCVI_LOAD_SYMBOL(NAME)                                                          \
+	{                                                                                    \
+		NAME = reinterpret_cast<decltype(NAME)>(_library->load_symbol(#NAME));           \
+		if (!NAME)                                                                       \
+			throw std::runtime_error("Failed to load '" #NAME "' from '" LIB_NAME "'."); \
+	}
+
+streamfx::nvidia::cv::cv::~cv()
+{
+	D_LOG_DEBUG("Finalizing... (Addr: 0x%" PRIuPTR ")", this);
+}
+
+streamfx::nvidia::cv::cv::cv()
+{
+	std::filesystem::path              vfx_sdk_path;
+	std::filesystem::path              ar_sdk_path;
+	std::vector<std::filesystem::path> lib_paths;
+
+	auto gctx = ::streamfx::obs::gs::context();
+	auto cctx = ::streamfx::nvidia::cuda::obs::get()->get_context()->enter();
+
+	D_LOG_DEBUG("Initializing... (Addr: 0x%" PRIuPTR ")", this);
+
+	// Figure out the location of supported SDKs.
+	{
+#ifdef WIN32
+		DWORD                env_size;
+		std::vector<wchar_t> buffer;
+		env_size = GetEnvironmentVariableW(ST_ENV_NVIDIA_VIDEO_EFFECTS_SDK_PATH, nullptr, 0);
+		if (env_size > 0) {
+			buffer.resize(static_cast<size_t>(env_size) + 1);
+			env_size     = GetEnvironmentVariableW(ST_ENV_NVIDIA_VIDEO_EFFECTS_SDK_PATH, buffer.data(), buffer.size());
+			vfx_sdk_path = std::wstring(buffer.data(), buffer.size());
+		} else {
+			PWSTR   str = nullptr;
+			HRESULT res = SHGetKnownFolderPath(FOLDERID_ProgramFiles, KF_FLAG_DEFAULT, nullptr, &str);
+			if (res == S_OK) {
+				vfx_sdk_path = std::wstring(str);
+				vfx_sdk_path /= "NVIDIA Corporation";
+				vfx_sdk_path /= "NVIDIA Video Effects";
+				CoTaskMemFree(str);
+			}
+		}
+#else
+		throw std::runtime_error("Not yet implemented.");
+#endif
+
+		// Check if any of the found paths are valid.
+		if (std::filesystem::exists(vfx_sdk_path)) {
+			lib_paths.push_back(vfx_sdk_path);
+		}
+	}
+	{
+#ifdef WIN32
+		DWORD                env_size;
+		std::vector<wchar_t> buffer;
+		env_size = GetEnvironmentVariableW(ST_ENV_NVIDIA_AR_SDK_PATH, nullptr, 0);
+		if (env_size > 0) {
+			buffer.resize(static_cast<size_t>(env_size) + 1);
+			env_size    = GetEnvironmentVariableW(ST_ENV_NVIDIA_AR_SDK_PATH, buffer.data(), buffer.size());
+			ar_sdk_path = std::wstring(buffer.data(), buffer.size());
+		} else {
+			PWSTR   str = nullptr;
+			HRESULT res = SHGetKnownFolderPath(FOLDERID_ProgramFiles, KF_FLAG_DEFAULT, nullptr, &str);
+			if (res == S_OK) {
+				ar_sdk_path = std::wstring(str);
+				ar_sdk_path /= "NVIDIA Corporation";
+				ar_sdk_path /= "NVIDIA AR SDK";
+				CoTaskMemFree(str);
+			}
+		}
+#else
+		throw std::runtime_error("Not yet implemented.");
+#endif
+
+		// Check if any of the found paths are valid.
+		if (std::filesystem::exists(ar_sdk_path)) {
+			lib_paths.push_back(ar_sdk_path);
+		}
+	}
+
+	// Check if we have any found paths.
+	if (lib_paths.size() == 0) {
+		D_LOG_ERROR("No supported NVIDIA SDK is installed to provide '%s'.", LIB_NAME);
+		throw std::runtime_error("Failed to load '" LIB_NAME "'.");
+	}
+
+	// Try and load any available NvCVImage library.
+	for (auto path : lib_paths) {
+#ifdef WIN32
+		// On platforms where it is possible, modify the linker directories.
+		SetDefaultDllDirectories(LOAD_LIBRARY_SEARCH_DEFAULT_DIRS);
+		DLL_DIRECTORY_COOKIE ck = AddDllDirectory(vfx_sdk_path.wstring().c_str());
+#endif
+
+		try {
+			// Try to load it directly first, it may be on the search path already.
+			_library = ::streamfx::util::library::load(std::string_view(LIB_NAME));
+		} catch (...) {
+			auto pathu8 = util::platform::native_to_utf8(path / LIB_NAME);
+			try {
+				_library = ::streamfx::util::library::load(pathu8);
+			} catch (...) {
+				D_LOG_WARNING("Failed to load '%s' from '%s'.", LIB_NAME, pathu8.string().c_str());
+			}
+		}
+		if (_library)
+			break;
+
+#ifdef WIN32
+		RemoveDllDirectory(ck);
+#endif
+	}
+
+	if (!_library) {
+		D_LOG_ERROR("No installed NVIDIA SDK provides '%s'.", LIB_NAME);
+		throw std::runtime_error("Failed to load '" LIB_NAME "'.");
+	}
+
+	{ // Load Symbols
+		NVCVI_LOAD_SYMBOL(NvCVImage_Init);
+		NVCVI_LOAD_SYMBOL(NvCVImage_InitView);
+		NVCVI_LOAD_SYMBOL(NvCVImage_Alloc);
+		NVCVI_LOAD_SYMBOL(NvCVImage_Realloc);
+		NVCVI_LOAD_SYMBOL(NvCVImage_Dealloc);
+		NVCVI_LOAD_SYMBOL(NvCVImage_Create);
+		NVCVI_LOAD_SYMBOL(NvCVImage_Destroy);
+		NVCVI_LOAD_SYMBOL(NvCVImage_ComponentOffsets);
+		NVCVI_LOAD_SYMBOL(NvCVImage_Transfer);
+		NVCVI_LOAD_SYMBOL(NvCVImage_TransferRect);
+		NVCVI_LOAD_SYMBOL(NvCVImage_TransferFromYUV);
+		NVCVI_LOAD_SYMBOL(NvCVImage_TransferToYUV);
+		NVCVI_LOAD_SYMBOL(NvCVImage_MapResource);
+		NVCVI_LOAD_SYMBOL(NvCVImage_UnmapResource);
+		NVCVI_LOAD_SYMBOL(NvCVImage_Composite);
+		NVCVI_LOAD_SYMBOL(NvCVImage_CompositeRect);
+		NVCVI_LOAD_SYMBOL(NvCVImage_CompositeOverConstant);
+		NVCVI_LOAD_SYMBOL(NvCVImage_FlipY);
+		NVCVI_LOAD_SYMBOL(NvCVImage_GetYUVPointers);
+		NVCVI_LOAD_SYMBOL(NvCV_GetErrorStringFromCode);
+#ifdef WIN32
+		NVCVI_LOAD_SYMBOL(NvCVImage_InitFromD3D11Texture);
+		NVCVI_LOAD_SYMBOL(NvCVImage_ToD3DFormat);
+		NVCVI_LOAD_SYMBOL(NvCVImage_FromD3DFormat);
+#ifdef __dxgicommon_h__
+		NVCVI_LOAD_SYMBOL(NvCVImage_ToD3DColorSpace);
+		NVCVI_LOAD_SYMBOL(NvCVImage_FromD3DColorSpace);
+#endif
+#endif
+	}
+}
+
+std::shared_ptr<streamfx::nvidia::cv::cv> streamfx::nvidia::cv::cv::get()
+{
+	static std::weak_ptr<streamfx::nvidia::cv::cv> instance;
+	static std::mutex                              lock;
+
+	std::unique_lock<std::mutex> ul(lock);
+	if (instance.expired()) {
+		auto hard_instance = std::make_shared<streamfx::nvidia::cv::cv>();
+		instance           = hard_instance;
+		return hard_instance;
+	}
+	return instance.lock();
+}

--- a/source/nvidia/cv/nvidia-cv.hpp
+++ b/source/nvidia/cv/nvidia-cv.hpp
@@ -1,0 +1,289 @@
+// Copyright (c) 2021 Michael Fabian Dirks <info@xaymar.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+#include <cinttypes>
+#include "nvidia/cuda/nvidia-cuda.hpp"
+#include "util/util-bitmask.hpp"
+#include "util/util-library.hpp"
+
+#ifdef WIN32
+#pragma warning(push)
+#pragma warning(disable : 4365)
+#pragma warning(disable : 5204)
+#include <d3d11.h>
+#include <dxgi.h>
+#pragma warning(pop)
+#endif
+
+#define NVCVI_DEFINE_FUNCTION(name, ...)                                   \
+	private:                                                               \
+	typedef ::streamfx::nvidia::cv::result(__cdecl* t##name)(__VA_ARGS__); \
+                                                                           \
+	public:                                                                \
+	t##name name = nullptr;
+
+#define NVCVI_DEFINE_FUNCTION_EX(ret, name, ...) \
+	private:                                     \
+	typedef ret(__cdecl* t##name)(__VA_ARGS__);  \
+                                                 \
+	public:                                      \
+	t##name name = nullptr;
+
+namespace streamfx::nvidia::cv {
+	enum class result {
+		// NVIDIA uses negative codes, but we use positive.
+		SUCCESS                 = 0,
+		ERROR_GENERAL           = -1,
+		ERROR_UNIMPLEMENTED     = -2,
+		ERROR_MEMORY            = -3,
+		ERROR_EFFECT            = -4,
+		ERROR_SELECTOR          = -5,
+		ERROR_BUFFER            = -6,
+		ERROR_PARAMETER         = -7,
+		ERROR_MISMATCH          = -8,
+		ERROR_PIXELFORMAT       = -9,
+		ERROR_MODEL             = -10,
+		ERROR_LIBRARY           = -11,
+		ERROR_INITIALIZATION    = -12,
+		ERROR_FILE              = -13,
+		ERROR_FEATURENOTFOUND   = -14,
+		ERROR_MISSINGINPUT      = -15,
+		ERROR_RESOLUTION        = -16,
+		ERROR_UNSUPPORTEDGPU    = -17,
+		ERROR_WRONGGPU          = -18,
+		ERROR_UNSUPPORTEDDRIVER = -19,
+		ERROR_MODELDEPENDENCIES = -20,
+		ERROR_PARSE             = -21,
+		ERROR_MODELSUBSTITUTION = -22,
+		ERROR_READ              = -23,
+		ERROR_WRITE             = -24,
+		ERROR_PARAMREADONLY     = -25,
+		ERROR_TRT_ENQUEUE       = -26,
+		ERROR_TRT_BINDINGS      = -27,
+		ERROR_TRT_CONTEXT       = -28,
+		ERROR_TRT_INFER         = -29,
+		ERROR_TRT_ENGINE        = -30,
+		ERROR_NPP               = -31,
+		ERROR_CONFIG            = -32,
+
+		// Error from Graphics API
+		ERROR_DIRECT3D = -99,
+
+		// Error from CUDA
+		ERROR_CUDA_BASE            = -100,
+		ERROR_CUDA_VALUE           = -101,
+		ERROR_CUDA_MEMORY          = -102,
+		ERROR_CUDA_PITCH           = -112,
+		ERROR_CUDA_INIT            = -127,
+		ERROR_CUDA_LAUNCH          = -819,
+		ERROR_CUDA_KERNEL          = -309,
+		ERROR_CUDA_DRIVER          = -135,
+		ERROR_CUDA_UNSUPPORTED     = -901,
+		ERROR_CUDA_ILLEGAL_ADDRESS = -800,
+		ERROR_CUDA                 = -1099,
+	};
+
+	enum class pixel_format {
+		UNKNOWN = 0,
+		Y       = 1,
+		A       = 2,
+		YA      = 3,
+		RGB     = 4,
+		BGR     = 5,
+		RGBA    = 6,
+		BGRA    = 7,
+		ARGB    = 8,
+		ABGR    = 9,
+		YUV420  = 10,
+		YUV422  = 11,
+		YUV444  = 12,
+	};
+
+	enum class component_type {
+		UKNOWN = 0,
+		UINT8  = 1,
+		UINT16 = 2,
+		SINT16 = 3,
+		FP16   = 4,
+		UINT32 = 5,
+		SINT   = 6,
+		FP32   = 7,
+		UINT64 = 8,
+		SINT64 = 9,
+		FP64   = 10,
+	};
+
+	enum class component_layout {
+		INTERLEAVED = 0,
+		PLANAR      = 1,
+		UYVY        = 2,
+		YUV         = 3,
+		VYUY        = 4,
+		YVU         = 5,
+		YUYV        = 6,
+		YCUV        = 7,
+		YVYU        = 8,
+		YCVU        = 9,
+		CYUV        = 10,
+		_RESERVED11 = 11,
+		CYVU        = 12,
+		CHUNKY      = INTERLEAVED,
+		I420        = YUV,
+		IYUV        = YUV,
+		YV12        = YVU,
+		NV12        = YCUV,
+		NV21        = YCVU,
+		YUY2        = YUYV,
+		I444        = YUV,
+		YM24        = YUV,
+		YM42        = YVU,
+		NV24        = YCUV,
+		NV42        = YCVU,
+	};
+
+	enum class color_information {
+		SPACE_BT_601                 = 0x00,
+		SPACE_BT_709                 = 0x01,
+		SPACE_BT_2020                = 0x02,
+		RANGE_PARTIAL                = 0x00,
+		RANGE_FULL                   = 0x04,
+		CHROMA_LOCATION_COSITED      = 0x00,
+		CHROMA_LOCATION_INTERSTITIAL = 0x08,
+		CHROMA_LOCATION_TOPLEFT      = 0x10,
+	};
+
+	enum class memory_location {
+		CPU        = 0,
+		GPU        = 1,
+		CPU_PINNED = 2,
+		CUDA_ARRAY = 3,
+	};
+
+	struct image_t {
+		uint32_t       width;
+		uint32_t       height;
+		int32_t        pitch;
+		pixel_format   pxl_format;
+		component_type comp_type;
+		uint8_t        pixel_bytes;
+		uint8_t        component_bytes;
+		uint8_t        num_components;
+		unsigned char  comp_layout;
+		unsigned char  mem_location;
+		unsigned char  color_info;
+		uint8_t        reserved[2];
+		void*          pixels;
+		void*          delete_pointer;
+		void (*delete_function)(void* delete_pointer);
+		uint64_t buffer_bytes;
+	};
+
+	template<typename T>
+	struct point {
+		T x, y;
+	};
+
+	template<typename T>
+	struct rect {
+		T x, y;
+		T w, h;
+	};
+
+	class cv {
+		std::shared_ptr<::streamfx::util::library> _library;
+
+		public:
+		~cv();
+		cv();
+
+		public:
+		NVCVI_DEFINE_FUNCTION(NvCVImage_Init, image_t* image, uint32_t width, uint32_t height, uint32_t pitch,
+							  void* pixels, pixel_format format, component_type comp_type, component_layout comp_layout,
+							  memory_location mem_location);
+		NVCVI_DEFINE_FUNCTION(NvCVImage_InitView, image_t* sub_image, image_t* image, int32_t x, int32_t y,
+							  uint32_t width, uint32_t height);
+		NVCVI_DEFINE_FUNCTION(NvCVImage_Alloc, image_t* image, uint32_t width, uint32_t height, pixel_format format,
+							  component_type comp_type, uint32_t comp_layout, uint32_t mem_location,
+							  uint32_t alignment);
+		NVCVI_DEFINE_FUNCTION(NvCVImage_Realloc, image_t* image, uint32_t width, uint32_t height, pixel_format format,
+							  component_type comp_type, uint32_t comp_layout, uint32_t mem_location,
+							  uint32_t alignment);
+		NVCVI_DEFINE_FUNCTION(NvCVImage_Dealloc, image_t* image);
+		NVCVI_DEFINE_FUNCTION(NvCVImage_Create, uint32_t width, uint32_t height, pixel_format format,
+							  component_type comp_type, component_layout comp_layout, memory_location mem_location,
+							  uint32_t alignment, image_t** image);
+		NVCVI_DEFINE_FUNCTION_EX(void, NvCVImage_Destroy, image_t* image);
+		NVCVI_DEFINE_FUNCTION_EX(void, NvCVImage_ComponentOffsets, pixel_format format, int32_t* red_offset,
+								 int32_t* green_offset, int32_t* blue_offset, int32_t* alpha_offset, int32_t* y_offset);
+		NVCVI_DEFINE_FUNCTION(NvCVImage_Transfer, const image_t* source, image_t* destination, float scale,
+							  ::streamfx::nvidia::cuda::stream_t stream, image_t* buffer);
+		NVCVI_DEFINE_FUNCTION(NvCVImage_TransferRect, const image_t* source, const rect<int32_t>* source_rect,
+							  image_t* destination, const point<int32_t>* destination_point, float scale,
+							  ::streamfx::nvidia::cuda::stream_t stream, image_t* buffer);
+		NVCVI_DEFINE_FUNCTION(NvCVImage_TransferFromYUV, const void* y, int32_t yPixBytes, int32_t yPitch,
+							  const void* u, const void* v, int32_t uvPixBytes, int32_t uvPitch, pixel_format yuvFormat,
+							  component_type yuvType, color_information yuvColorSpace, memory_location yuvMemSpace,
+							  image_t* destination, const rect<int32_t>* destination_area, float scale,
+							  ::streamfx::nvidia::cuda::stream_t stream, image_t* tmp);
+		NVCVI_DEFINE_FUNCTION(NvCVImage_TransferToYUV, const image_t* source, const rect<int32_t>* source_area,
+							  const void* y, int32_t yPixBytes, int32_t yPitch, const void* u, const void* v,
+							  int uvPixBytes, int32_t uvPitch, pixel_format yuvFormat, component_type yuvType,
+							  color_information yuvColorSpace, memory_location yuvMemSpace, float scale,
+							  ::streamfx::nvidia::cuda::stream_t stream, image_t* tmp);
+		NVCVI_DEFINE_FUNCTION(NvCVImage_MapResource, image_t* image, ::streamfx::nvidia::cuda::stream_t stream);
+		NVCVI_DEFINE_FUNCTION(NvCVImage_UnmapResource, image_t* image, ::streamfx::nvidia::cuda::stream_t stream);
+		NVCVI_DEFINE_FUNCTION(NvCVImage_Composite, const image_t* foreground, const image_t* background,
+							  const image_t* matte, image_t* destination, ::streamfx::nvidia::cuda::stream_t stream);
+		NVCVI_DEFINE_FUNCTION(NvCVImage_CompositeRect, const image_t* foreground,
+							  const point<int32_t> foreground_origin, const image_t* background,
+							  const point<int32_t> background_origin, const image_t* matte, uint32_t mode,
+							  image_t* destination, const point<int32_t> destination_origin,
+							  ::streamfx::nvidia::cuda::stream_t stream);
+		NVCVI_DEFINE_FUNCTION(NvCVImage_CompositeOverConstant, const image_t* source, const image_t* matte,
+							  const uint8_t background_color[3], image_t* destination);
+		NVCVI_DEFINE_FUNCTION(NvCVImage_FlipY, const image_t* source, image_t* destination);
+		NVCVI_DEFINE_FUNCTION(NvCVImage_GetYUVPointers, image_t* image, uint8_t** y, uint8_t** u, uint8_t** v,
+							  int32_t* y_pixel_bytes, int32_t* c_pixel_bytes, int32_t* y_row_bytes,
+							  int32_t* c_row_bytes);
+
+		NVCVI_DEFINE_FUNCTION_EX(const char*, NvCV_GetErrorStringFromCode, result code);
+
+#ifdef WIN32
+		NVCVI_DEFINE_FUNCTION(NvCVImage_InitFromD3D11Texture, image_t* image, struct ID3D11Texture2D* texture);
+		NVCVI_DEFINE_FUNCTION(NvCVImage_ToD3DFormat, pixel_format format, component_type comp_type,
+							  component_layout comp_layout, DXGI_FORMAT* dxgi_format);
+		NVCVI_DEFINE_FUNCTION(NvCVImage_FromD3DFormat, DXGI_FORMAT d3dFormat, pixel_format* format,
+							  component_type* comp_type, component_layout* comp_layout);
+
+#ifdef __dxgicommon_h__
+		NVCVI_DEFINE_FUNCTION(NvCVImage_ToD3DColorSpace, color_information nvcvColorSpace,
+							  DXGI_COLOR_SPACE_TYPE* pD3dColorSpace);
+		NVCVI_DEFINE_FUNCTION(NvCVImage_FromD3DColorSpace, DXGI_COLOR_SPACE_TYPE d3dColorSpace,
+							  color_information* pNvcvColorSpace);
+#endif
+#endif
+
+		public:
+		static std::shared_ptr<::streamfx::nvidia::cv::cv> get();
+	};
+} // namespace streamfx::nvidia::cv
+
+P_ENABLE_BITMASK_OPERATORS(::streamfx::nvidia::cv::color_information);

--- a/source/nvidia/vfx/nvidia-vfx-superresolution.cpp
+++ b/source/nvidia/vfx/nvidia-vfx-superresolution.cpp
@@ -1,0 +1,416 @@
+// Copyright (c) 2020 Michael Fabian Dirks <info@xaymar.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "nvidia-vfx-superresolution.hpp"
+#include <utility>
+#include "obs/gs/gs-helper.hpp"
+#include "util/util-logging.hpp"
+#include "util/utility.hpp"
+
+#ifdef _DEBUG
+#define ST_PREFIX "<%s> "
+#define D_LOG_ERROR(x, ...) P_LOG_ERROR(ST_PREFIX##x, __FUNCTION_SIG__, __VA_ARGS__)
+#define D_LOG_WARNING(x, ...) P_LOG_WARN(ST_PREFIX##x, __FUNCTION_SIG__, __VA_ARGS__)
+#define D_LOG_INFO(x, ...) P_LOG_INFO(ST_PREFIX##x, __FUNCTION_SIG__, __VA_ARGS__)
+#define D_LOG_DEBUG(x, ...) P_LOG_DEBUG(ST_PREFIX##x, __FUNCTION_SIG__, __VA_ARGS__)
+#else
+#define ST_PREFIX "<nvidia::vfx::superresolution::superresolution> "
+#define D_LOG_ERROR(...) P_LOG_ERROR(ST_PREFIX __VA_ARGS__)
+#define D_LOG_WARNING(...) P_LOG_WARN(ST_PREFIX __VA_ARGS__)
+#define D_LOG_INFO(...) P_LOG_INFO(ST_PREFIX __VA_ARGS__)
+#define D_LOG_DEBUG(...) P_LOG_DEBUG(ST_PREFIX __VA_ARGS__)
+#endif
+
+streamfx::nvidia::vfx::superresolution::~superresolution()
+{
+	auto gctx = ::streamfx::obs::gs::context();
+	auto cctx = ::streamfx::nvidia::cuda::obs::get()->get_context()->enter();
+
+	_fx.reset();
+
+	// Clean up any CUDA resources in use.
+	_input.reset();
+	_convert_to_fp32.reset();
+	_source.reset();
+	_destination.reset();
+	_convert_to_u8.reset();
+	_output.reset();
+	_tmp.reset();
+
+	// Release CUDA, CVImage, and Video Effects SDK.
+	_nvvfx.reset();
+	_nvcvi.reset();
+	_nvcuda.reset();
+}
+
+streamfx::nvidia::vfx::superresolution::superresolution()
+	: _nvcuda(::streamfx::nvidia::cuda::obs::get()), _nvcvi(::streamfx::nvidia::cv::cv::get()),
+	  _nvvfx(::streamfx::nvidia::vfx::vfx::get()), _strength(1.), _scale(1.5), _input(), _source(), _destination(),
+	  _convert_to_u8(), _output(), _tmp(), _dirty(true)
+{
+	// Enter Graphics and CUDA context.
+	auto gctx = ::streamfx::obs::gs::context();
+	auto cctx = ::streamfx::nvidia::cuda::obs::get()->get_context()->enter();
+
+	{ // Try & Create the Super-Resolution effect.
+		::streamfx::nvidia::vfx::handle_t handle;
+		if (auto res = _nvvfx->NvVFX_CreateEffect(::streamfx::nvidia::vfx::EFFECT_SUPERRESOLUTION, &handle);
+			res != ::streamfx::nvidia::cv::result::SUCCESS) {
+			D_LOG_ERROR("Failed to create effect due to error: %s", _nvcvi->NvCV_GetErrorStringFromCode(res));
+			throw std::runtime_error("CreateEffect failed.");
+		}
+
+		_fx = std::shared_ptr<void>(handle, [](::streamfx::nvidia::vfx::handle_t handle) {
+			::streamfx::nvidia::vfx::vfx::get()->NvVFX_DestroyEffect(handle);
+		});
+	}
+
+	// Assign the appropriate CUDA stream.
+	if (auto res = _nvvfx->NvVFX_SetCudaStream(_fx.get(), ::streamfx::nvidia::vfx::PARAMETER_CUDA_STREAM,
+											   _nvcuda->get_stream()->get());
+		res != ::streamfx::nvidia::cv::result::SUCCESS) {
+		D_LOG_ERROR("Failed to set CUDA stream due to error: %s", _nvcvi->NvCV_GetErrorStringFromCode(res));
+		throw std::runtime_error("SetCudaStream failed.");
+	}
+
+	// Set the proper model directory.
+	if (auto res = _nvvfx->NvVFX_SetString(_fx.get(), ::streamfx::nvidia::vfx::PARAMETER_MODEL_DIRECTORY,
+										   _nvvfx->model_path().generic_u8string().c_str());
+		res != ::streamfx::nvidia::cv::result::SUCCESS) {
+		D_LOG_ERROR("Failed to set model directory due to error: %s", _nvcvi->NvCV_GetErrorStringFromCode(res));
+		throw std::runtime_error("SetString failed.");
+	}
+
+	// Set the strength, scale and buffers.
+	set_strength(_strength);
+	set_scale(_scale);
+	resize(160, 90);
+
+	// Load the effect.
+	load();
+}
+
+void streamfx::nvidia::vfx::superresolution::set_strength(float strength)
+{
+	strength = (strength >= .5f) ? 1.f : 0.f;
+	std::swap(_strength, strength);
+
+	// If anything was changed, flag the effect as dirty.
+	if (!::streamfx::util::math::is_close<float>(_strength, strength, 0.01))
+		_dirty = true;
+
+	// Update Effect
+	uint32_t value = (_strength >= .5f) ? 1 : 0;
+	auto     gctx  = ::streamfx::obs::gs::context();
+	auto     cctx  = ::streamfx::nvidia::cuda::obs::get()->get_context()->enter();
+	if (auto res = _nvvfx->NvVFX_SetU32(_fx.get(), ::streamfx::nvidia::vfx::PARAMETER_STRENGTH, value);
+		res != ::streamfx::nvidia::cv::result::SUCCESS) {
+		D_LOG_ERROR("Failed to set '%s' to %lu.", ::streamfx::nvidia::vfx::PARAMETER_STRENGTH, value);
+	};
+}
+
+float streamfx::nvidia::vfx::superresolution::strength()
+{
+	return _strength;
+}
+
+void streamfx::nvidia::vfx::superresolution::set_scale(float scale)
+{
+	// Limit to acceptable range.
+	scale = std::clamp<float>(scale, 1., 4.);
+
+	// Match to nearest scale.
+	std::pair<float, float> minimal = {0., std::numeric_limits<float>::max()};
+	std::vector<float>      deltas{
+        1. + (1. / 3.), 1.5, 2.0, 3.0, 4.0,
+    };
+	for (float delta : deltas) {
+		float value = abs(delta - scale);
+		if (minimal.second > value) {
+			minimal.first  = delta;
+			minimal.second = value;
+		}
+	}
+
+	// If anything was changed, flag the effect as dirty.
+	if (!::streamfx::util::math::is_close<float>(_scale, minimal.first, 0.01))
+		_dirty = true;
+
+	_scale = minimal.first;
+}
+
+float streamfx::nvidia::vfx::superresolution::scale()
+{
+	return _scale;
+}
+
+void streamfx::nvidia::vfx::superresolution::size(std::pair<uint32_t, uint32_t> const& size,
+												  std::pair<uint32_t, uint32_t>&       input_size,
+												  std::pair<uint32_t, uint32_t>&       output_size)
+{
+	constexpr uint32_t min_width  = 160;
+	constexpr uint32_t min_height = 90;
+	uint32_t           max_width  = 0;
+	uint32_t           max_height = 0;
+
+	if (_scale > 3.0) {
+		max_width  = 960;
+		max_height = 540;
+	} else if (_scale > 2.0) {
+		max_width  = 1280;
+		max_height = 720;
+	} else {
+		max_width  = 1920;
+		max_height = 1080;
+	}
+
+	// Calculate Input Size
+	if (input_size.first > input_size.second) {
+		// Dominant Width
+		double ar         = static_cast<double>(input_size.second) / static_cast<double>(input_size.first);
+		input_size.first  = std::clamp<uint32_t>(input_size.first, min_width, max_width);
+		input_size.second = std::clamp<uint32_t>(
+			static_cast<uint32_t>(round(static_cast<double>(input_size.first) * ar)), min_height, max_height);
+	} else {
+		// Dominant Height
+		double ar         = static_cast<double>(input_size.first) / static_cast<double>(input_size.second);
+		input_size.second = std::clamp<uint32_t>(input_size.second, min_height, max_height);
+		input_size.first  = std::clamp<uint32_t>(
+            static_cast<uint32_t>(round(static_cast<double>(input_size.second) * ar)), min_width, max_width);
+	}
+
+	// Calculate Output Size.
+	output_size.first  = static_cast<uint32_t>(input_size.first * _scale);
+	output_size.second = static_cast<uint32_t>(input_size.second * _scale);
+}
+
+std::shared_ptr<::streamfx::obs::gs::texture>
+	streamfx::nvidia::vfx::superresolution::process(std::shared_ptr<::streamfx::obs::gs::texture> in)
+{
+	// Enter Graphics and CUDA context.
+	auto gctx = ::streamfx::obs::gs::context();
+	auto cctx = _nvcuda->get_context()->enter();
+
+#ifdef ENABLE_PROFILING
+	::streamfx::obs::gs::debug_marker profiler1{::streamfx::obs::gs::debug_color_magenta, "NvVFX Super-Resolution"};
+#endif
+
+	// Resize if the size or scale was changed.
+	resize(in->get_width(), in->get_height());
+
+	// Reload effect if dirty.
+	if (_dirty) {
+		load();
+	}
+
+	{ // Copy parameter to input.
+#ifdef ENABLE_PROFILING
+		::streamfx::obs::gs::debug_marker profiler1{::streamfx::obs::gs::debug_color_copy, "Copy In -> Input"};
+#endif
+		gs_copy_texture(_input->get_texture()->get_object(), in->get_object());
+	}
+
+	{ // Convert Input to Source format
+#ifdef ENABLE_PROFILING
+		::streamfx::obs::gs::debug_marker profiler1{::streamfx::obs::gs::debug_color_convert,
+													"Convert Input -> Source"};
+#endif
+		if (auto res = _nvcvi->NvCVImage_Transfer(_input->get_image(), _convert_to_fp32->get_image(), 1.f,
+												  _nvcuda->get_stream()->get(), _tmp->get_image());
+			res != ::streamfx::nvidia::cv::result::SUCCESS) {
+			D_LOG_ERROR("Failed to transfer processing result to output due to error: %s",
+						_nvcvi->NvCV_GetErrorStringFromCode(res));
+			throw std::runtime_error("Transfer failed.");
+		}
+	}
+
+	{ // Copy input to source.
+#ifdef ENABLE_PROFILING
+		::streamfx::obs::gs::debug_marker profiler1{::streamfx::obs::gs::debug_color_copy, "Copy Input -> Source"};
+#endif
+		if (auto res = _nvcvi->NvCVImage_Transfer(_convert_to_fp32->get_image(), _source->get_image(), 1.f,
+												  _nvcuda->get_stream()->get(), _tmp->get_image());
+			res != ::streamfx::nvidia::cv::result::SUCCESS) {
+			D_LOG_ERROR("Failed to transfer input to processing source due to error: %s",
+						_nvcvi->NvCV_GetErrorStringFromCode(res));
+			throw std::runtime_error("Transfer failed.");
+		}
+	}
+
+	{ // Process source to destination.
+#ifdef ENABLE_PROFILING
+		::streamfx::obs::gs::debug_marker profiler1{::streamfx::obs::gs::debug_color_cache, "Process"};
+#endif
+		if (auto res = _nvvfx->NvVFX_Run(_fx.get(), 0); res != ::streamfx::nvidia::cv::result::SUCCESS) {
+			D_LOG_ERROR("Failed to process due to error: %s", _nvcvi->NvCV_GetErrorStringFromCode(res));
+			throw std::runtime_error("Run failed.");
+		}
+	}
+
+	{ // Convert Destination to Output format
+#ifdef ENABLE_PROFILING
+		::streamfx::obs::gs::debug_marker profiler1{::streamfx::obs::gs::debug_color_convert,
+													"Convert Destination -> Output"};
+#endif
+		if (auto res = _nvcvi->NvCVImage_Transfer(_destination->get_image(), _convert_to_u8->get_image(), 1.f,
+												  _nvcuda->get_stream()->get(), _tmp->get_image());
+			res != ::streamfx::nvidia::cv::result::SUCCESS) {
+			D_LOG_ERROR("Failed to transfer processing result to output due to error: %s",
+						_nvcvi->NvCV_GetErrorStringFromCode(res));
+			throw std::runtime_error("Transfer failed.");
+		}
+	}
+
+	{ // Copy destination to output.
+#ifdef ENABLE_PROFILING
+		::streamfx::obs::gs::debug_marker profiler1{::streamfx::obs::gs::debug_color_copy,
+													"Copy Destination -> Output"};
+#endif
+		if (auto res = _nvcvi->NvCVImage_Transfer(_convert_to_u8->get_image(), _output->get_image(), 1.,
+												  _nvcuda->get_stream()->get(), _tmp->get_image());
+			res != ::streamfx::nvidia::cv::result::SUCCESS) {
+			D_LOG_ERROR("Failed to transfer processing result to output due to error: %s",
+						_nvcvi->NvCV_GetErrorStringFromCode(res));
+			throw std::runtime_error("Transfer failed.");
+		}
+	}
+
+	// Return output.
+	return _output->get_texture();
+}
+
+void streamfx::nvidia::vfx::superresolution::resize(uint32_t width, uint32_t height)
+{
+	uint32_t out_width  = static_cast<uint32_t>(width * _scale);
+	uint32_t out_height = static_cast<uint32_t>(height * _scale);
+
+	auto gctx = ::streamfx::obs::gs::context();
+	auto cctx = ::streamfx::nvidia::cuda::obs::get()->get_context()->enter();
+
+	if (!_tmp) {
+		_tmp = std::make_shared<::streamfx::nvidia::cv::image>(
+			out_width, out_height, ::streamfx::nvidia::cv::pixel_format::RGBA,
+			::streamfx::nvidia::cv::component_type::UINT8, ::streamfx::nvidia::cv::component_layout::PLANAR,
+			::streamfx::nvidia::cv::memory_location::GPU, 1);
+	}
+
+	// Input Size was changed.
+	if (!_input || !_source || (width != _input->get_texture()->get_width())
+		|| (height != _input->get_texture()->get_height())) {
+		if (_input) {
+			_input->resize(width, height);
+		} else {
+			_input = std::make_shared<::streamfx::nvidia::cv::texture>(width, height, GS_RGBA_UNORM);
+		}
+
+		if (_source) {
+			_source->resize(width, height);
+		} else {
+			_source = std::make_shared<::streamfx::nvidia::cv::image>(
+				width, height, ::streamfx::nvidia::cv::pixel_format::BGR, ::streamfx::nvidia::cv::component_type::FP32,
+				::streamfx::nvidia::cv::component_layout::PLANAR, ::streamfx::nvidia::cv::memory_location::GPU, 1);
+		}
+
+		if (_convert_to_fp32) {
+			_convert_to_fp32->reallocate(out_width, out_height, ::streamfx::nvidia::cv::pixel_format::RGBA,
+										 ::streamfx::nvidia::cv::component_type::FP32,
+										 ::streamfx::nvidia::cv::component_layout::PLANAR,
+										 ::streamfx::nvidia::cv::memory_location::GPU, 1);
+		} else {
+			_convert_to_fp32 = std::make_shared<::streamfx::nvidia::cv::image>(
+				out_width, out_height, ::streamfx::nvidia::cv::pixel_format::RGBA,
+				::streamfx::nvidia::cv::component_type::FP32, ::streamfx::nvidia::cv::component_layout::PLANAR,
+				::streamfx::nvidia::cv::memory_location::GPU, 1);
+		}
+
+		if (auto res = _nvvfx->NvVFX_SetImage(_fx.get(), ::streamfx::nvidia::vfx::PARAMETER_INPUT_IMAGE_0,
+											  _source->get_image());
+			res != ::streamfx::nvidia::cv::result::SUCCESS) {
+			D_LOG_ERROR("Failed to set input image due to error: %s", _nvcvi->NvCV_GetErrorStringFromCode(res));
+			throw std::runtime_error("SetImage failed.");
+		}
+
+		_dirty = true;
+	}
+
+	// Input Size or Scale was changed.
+	if (!_destination || !_output || (out_width != _output->get_texture()->get_width())
+		|| (out_height != _output->get_texture()->get_height())) {
+		if (_destination) {
+			_destination->resize(out_width, out_height);
+		} else {
+			_destination = std::make_shared<::streamfx::nvidia::cv::image>(
+				out_width, out_height, ::streamfx::nvidia::cv::pixel_format::BGR,
+				::streamfx::nvidia::cv::component_type::FP32, ::streamfx::nvidia::cv::component_layout::PLANAR,
+				::streamfx::nvidia::cv::memory_location::GPU, 1);
+		}
+
+		if (_output) {
+			_output->resize(out_width, out_height);
+		} else {
+			_output = std::make_shared<::streamfx::nvidia::cv::texture>(out_width, out_height, GS_RGBA_UNORM);
+		}
+
+		if (_convert_to_u8) {
+			_convert_to_u8->reallocate(out_width, out_height, ::streamfx::nvidia::cv::pixel_format::RGBA,
+									   ::streamfx::nvidia::cv::component_type::UINT8,
+									   ::streamfx::nvidia::cv::component_layout::INTERLEAVED,
+									   ::streamfx::nvidia::cv::memory_location::GPU, 1);
+		} else {
+			_convert_to_u8 = std::make_shared<::streamfx::nvidia::cv::image>(
+				out_width, out_height, ::streamfx::nvidia::cv::pixel_format::RGBA,
+				::streamfx::nvidia::cv::component_type::UINT8, ::streamfx::nvidia::cv::component_layout::INTERLEAVED,
+				::streamfx::nvidia::cv::memory_location::GPU, 1);
+		}
+
+		if (auto res = _nvvfx->NvVFX_SetImage(_fx.get(), ::streamfx::nvidia::vfx::PARAMETER_OUTPUT_IMAGE_0,
+											  _destination->get_image());
+			res != ::streamfx::nvidia::cv::result::SUCCESS) {
+			D_LOG_ERROR("Failed to set output image due to error: %s", _nvcvi->NvCV_GetErrorStringFromCode(res));
+			throw std::runtime_error("SetImage failed.");
+		}
+
+		_dirty = true;
+	}
+}
+
+void streamfx::nvidia::vfx::superresolution::load()
+{
+	auto gctx = ::streamfx::obs::gs::context();
+	{
+		auto cctx = ::streamfx::nvidia::cuda::obs::get()->get_context()->enter();
+		if (auto res = _nvvfx->NvVFX_SetCudaStream(_fx.get(), ::streamfx::nvidia::vfx::PARAMETER_CUDA_STREAM,
+												   _nvcuda->get_stream()->get());
+			res != ::streamfx::nvidia::cv::result::SUCCESS) {
+			D_LOG_ERROR("Failed to set CUDA stream due to error: %s", _nvcvi->NvCV_GetErrorStringFromCode(res));
+			throw std::runtime_error("SetCudaStream failed.");
+		}
+	}
+
+	{
+		auto cctx = ::streamfx::nvidia::cuda::obs::get()->get_context()->enter();
+		if (auto res = _nvvfx->NvVFX_Load(_fx.get()); res != ::streamfx::nvidia::cv::result::SUCCESS) {
+			D_LOG_ERROR("Failed to initialize effect due to error: %s", _nvcvi->NvCV_GetErrorStringFromCode(res));
+			throw std::runtime_error("Load failed.");
+		}
+	}
+
+	_dirty = false;
+}

--- a/source/nvidia/vfx/nvidia-vfx-superresolution.hpp
+++ b/source/nvidia/vfx/nvidia-vfx-superresolution.hpp
@@ -1,0 +1,70 @@
+// Copyright (c) 2020 Michael Fabian Dirks <info@xaymar.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+#include "nvidia-vfx.hpp"
+#include "nvidia/cuda/nvidia-cuda-gs-texture.hpp"
+#include "nvidia/cuda/nvidia-cuda-obs.hpp"
+#include "nvidia/cuda/nvidia-cuda.hpp"
+#include "nvidia/cv/nvidia-cv-image.hpp"
+#include "nvidia/cv/nvidia-cv-texture.hpp"
+#include "obs/gs/gs-texture.hpp"
+
+namespace streamfx::nvidia::vfx {
+	class superresolution {
+		std::shared_ptr<::streamfx::nvidia::cuda::obs> _nvcuda;
+		std::shared_ptr<::streamfx::nvidia::cv::cv>    _nvcvi;
+		std::shared_ptr<::streamfx::nvidia::vfx::vfx>  _nvvfx;
+		std::shared_ptr<void>                          _fx;
+
+		std::shared_ptr<::streamfx::nvidia::cv::texture> _input;
+		std::shared_ptr<::streamfx::nvidia::cv::image>   _convert_to_fp32;
+		std::shared_ptr<::streamfx::nvidia::cv::image>   _source;
+		std::shared_ptr<::streamfx::nvidia::cv::image>   _destination;
+		std::shared_ptr<::streamfx::nvidia::cv::image>   _convert_to_u8;
+		std::shared_ptr<::streamfx::nvidia::cv::texture> _output;
+		std::shared_ptr<::streamfx::nvidia::cv::image>   _tmp;
+
+		float _strength;
+		float _scale;
+
+		bool _dirty;
+
+		public:
+		~superresolution();
+		superresolution();
+
+		void  set_strength(float strength);
+		float strength();
+
+		void  set_scale(float scale);
+		float scale();
+
+		void size(std::pair<uint32_t, uint32_t> const& size, std::pair<uint32_t, uint32_t>& input_size,
+				  std::pair<uint32_t, uint32_t>& output_size);
+
+		std::shared_ptr<::streamfx::obs::gs::texture> process(std::shared_ptr<::streamfx::obs::gs::texture> in);
+
+		private:
+		void resize(uint32_t width, uint32_t height);
+
+		void load();
+	};
+} // namespace streamfx::nvidia::vfx

--- a/source/nvidia/vfx/nvidia-vfx.cpp
+++ b/source/nvidia/vfx/nvidia-vfx.cpp
@@ -1,0 +1,193 @@
+// Copyright (c) 2020 Michael Fabian Dirks <info@xaymar.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "nvidia-vfx.hpp"
+#include <filesystem>
+#include <mutex>
+#include "nvidia/cuda/nvidia-cuda-obs.hpp"
+#include "obs/gs/gs-helper.hpp"
+#include "util/util-logging.hpp"
+#include "util/util-platform.hpp"
+
+#ifdef _DEBUG
+#define ST_PREFIX "<%s> "
+#define D_LOG_ERROR(x, ...) P_LOG_ERROR(ST_PREFIX##x, __FUNCTION_SIG__, __VA_ARGS__)
+#define D_LOG_WARNING(x, ...) P_LOG_WARN(ST_PREFIX##x, __FUNCTION_SIG__, __VA_ARGS__)
+#define D_LOG_INFO(x, ...) P_LOG_INFO(ST_PREFIX##x, __FUNCTION_SIG__, __VA_ARGS__)
+#define D_LOG_DEBUG(x, ...) P_LOG_DEBUG(ST_PREFIX##x, __FUNCTION_SIG__, __VA_ARGS__)
+#else
+#define ST_PREFIX "<nvidia::vfx::vfx> "
+#define D_LOG_ERROR(...) P_LOG_ERROR(ST_PREFIX __VA_ARGS__)
+#define D_LOG_WARNING(...) P_LOG_WARN(ST_PREFIX __VA_ARGS__)
+#define D_LOG_INFO(...) P_LOG_INFO(ST_PREFIX __VA_ARGS__)
+#define D_LOG_DEBUG(...) P_LOG_DEBUG(ST_PREFIX __VA_ARGS__)
+#endif
+
+#if defined(WIN32)
+#include <KnownFolders.h>
+#include <ShlObj.h>
+#include <Windows.h>
+
+#define LIB_NAME "NVVideoEffects.dll"
+#else
+#define LIB_NAME "libNVVideoEffects.so"
+#endif
+
+#define ST_ENV_NVIDIA_VIDEO_EFFECTS_SDK_PATH L"NV_VIDEO_EFFECTS_PATH"
+
+#define NVVFX_LOAD_SYMBOL(NAME)                                                          \
+	{                                                                                    \
+		NAME = reinterpret_cast<decltype(NAME)>(_library->load_symbol(#NAME));           \
+		if (!NAME)                                                                       \
+			throw std::runtime_error("Failed to load '" #NAME "' from '" LIB_NAME "'."); \
+	}
+
+streamfx::nvidia::vfx::vfx::~vfx()
+{
+	D_LOG_DEBUG("Finalizing... (Addr: 0x%" PRIuPTR ")", this);
+
+	auto gctx = ::streamfx::obs::gs::context();
+	auto cctx = ::streamfx::nvidia::cuda::obs::get()->get_context()->enter();
+
+	_library.reset();
+}
+
+streamfx::nvidia::vfx::vfx::vfx()
+{
+	std::filesystem::path sdk_path;
+	auto                  gctx = ::streamfx::obs::gs::context();
+	auto                  cctx = ::streamfx::nvidia::cuda::obs::get()->get_context()->enter();
+
+	D_LOG_DEBUG("Initializing... (Addr: 0x%" PRIuPTR ")", this);
+
+	// Figure out the location of the Video Effects SDK, if it is installed.
+#ifdef WIN32
+	{
+		DWORD                env_size;
+		std::vector<wchar_t> buffer;
+
+		env_size = GetEnvironmentVariableW(ST_ENV_NVIDIA_VIDEO_EFFECTS_SDK_PATH, nullptr, 0);
+		if (env_size > 0) {
+			buffer.resize(static_cast<size_t>(env_size) + 1);
+			env_size = GetEnvironmentVariableW(ST_ENV_NVIDIA_VIDEO_EFFECTS_SDK_PATH, buffer.data(), buffer.size());
+			sdk_path = std::wstring(buffer.data(), buffer.size());
+		} else {
+			PWSTR   str = nullptr;
+			HRESULT res = SHGetKnownFolderPath(FOLDERID_ProgramFiles, KF_FLAG_DEFAULT, nullptr, &str);
+			if (res == S_OK) {
+				sdk_path = std::wstring(str);
+				CoTaskMemFree(str);
+				sdk_path /= "NVIDIA Corporation";
+				sdk_path /= "NVIDIA Video Effects";
+			}
+		}
+	}
+#else
+	throw std::runtime_error("Not yet implemented.");
+#endif
+
+	// Check if any of the found paths are valid.
+	if (!std::filesystem::exists(sdk_path)) {
+		D_LOG_ERROR("No supported NVIDIA SDK is installed to provide '%s'.", LIB_NAME);
+		throw std::runtime_error("Failed to load '" LIB_NAME "'.");
+	}
+
+#ifdef WIN32
+	// On platforms where it is possible, modify the linker directories.
+	SetDefaultDllDirectories(LOAD_LIBRARY_SEARCH_DEFAULT_DIRS);
+	DLL_DIRECTORY_COOKIE ck = AddDllDirectory(sdk_path.wstring().c_str());
+#endif
+
+	// Try and load the libraries
+	if (!_library) {
+		// Load it by name.
+		try {
+			_library = ::streamfx::util::library::load(std::string_view(LIB_NAME));
+		} catch (...) {
+			// Load it by path.
+			auto lib_path = sdk_path;
+			lib_path /= LIB_NAME;
+			try {
+				_library = ::streamfx::util::library::load(util::platform::native_to_utf8(lib_path));
+			} catch (std::exception const& ex) {
+				D_LOG_ERROR("Failed to load '%s' from '%s' with error: %s", LIB_NAME,
+							util::platform::native_to_utf8(lib_path).string().c_str(), ex.what());
+				throw std::runtime_error("Failed to load '" LIB_NAME "'.");
+			} catch (...) {
+				D_LOG_ERROR("Failed to load '%s' from '%s'.", LIB_NAME,
+							util::platform::native_to_utf8(lib_path).string().c_str());
+				throw std::runtime_error("Failed to load '" LIB_NAME "'.");
+			}
+		}
+	}
+
+	// Store the model path for later use.
+	_model_path = std::filesystem::path(sdk_path) / "models";
+
+	{ // Load Symbols
+		NVVFX_LOAD_SYMBOL(NvVFX_GetVersion);
+		NVVFX_LOAD_SYMBOL(NvVFX_CreateEffect);
+		NVVFX_LOAD_SYMBOL(NvVFX_DestroyEffect);
+		NVVFX_LOAD_SYMBOL(NvVFX_SetU32);
+		NVVFX_LOAD_SYMBOL(NvVFX_SetS32);
+		NVVFX_LOAD_SYMBOL(NvVFX_SetF32);
+		NVVFX_LOAD_SYMBOL(NvVFX_SetF64);
+		NVVFX_LOAD_SYMBOL(NvVFX_SetU64);
+		NVVFX_LOAD_SYMBOL(NvVFX_SetImage);
+		NVVFX_LOAD_SYMBOL(NvVFX_SetObject);
+		NVVFX_LOAD_SYMBOL(NvVFX_SetString);
+		NVVFX_LOAD_SYMBOL(NvVFX_SetCudaStream);
+		NVVFX_LOAD_SYMBOL(NvVFX_GetU32);
+		NVVFX_LOAD_SYMBOL(NvVFX_GetS32);
+		NVVFX_LOAD_SYMBOL(NvVFX_GetF32);
+		NVVFX_LOAD_SYMBOL(NvVFX_GetF64);
+		NVVFX_LOAD_SYMBOL(NvVFX_GetU64);
+		NVVFX_LOAD_SYMBOL(NvVFX_GetImage);
+		NVVFX_LOAD_SYMBOL(NvVFX_GetObject);
+		NVVFX_LOAD_SYMBOL(NvVFX_GetString);
+		NVVFX_LOAD_SYMBOL(NvVFX_GetCudaStream);
+		NVVFX_LOAD_SYMBOL(NvVFX_Run);
+		NVVFX_LOAD_SYMBOL(NvVFX_Load);
+	}
+
+	{ // Assign proper GPU.
+		auto cctx = ::streamfx::nvidia::cuda::obs::get()->get_context()->enter();
+		NvVFX_SetU32(nullptr, PARAMETER_GPU, 0);
+	}
+}
+
+std::shared_ptr<::streamfx::nvidia::vfx::vfx> streamfx::nvidia::vfx::vfx::get()
+{
+	static std::weak_ptr<streamfx::nvidia::vfx::vfx> instance;
+	static std::mutex                                lock;
+
+	std::unique_lock<std::mutex> ul(lock);
+	if (instance.expired()) {
+		auto hard_instance = std::make_shared<streamfx::nvidia::vfx::vfx>();
+		instance           = hard_instance;
+		return hard_instance;
+	}
+	return instance.lock();
+}
+
+std::filesystem::path streamfx::nvidia::vfx::vfx::model_path()
+{
+	return _model_path;
+}

--- a/source/nvidia/vfx/nvidia-vfx.hpp
+++ b/source/nvidia/vfx/nvidia-vfx.hpp
@@ -1,0 +1,105 @@
+// Copyright (c) 2021 Michael Fabian Dirks <info@xaymar.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+#include <cinttypes>
+#include "nvidia/cv/nvidia-cv.hpp"
+
+#define NVVFX_DEFINE_FUNCTION(name, ...)                                   \
+	private:                                                               \
+	typedef ::streamfx::nvidia::cv::result(__cdecl* t##name)(__VA_ARGS__); \
+                                                                           \
+	public:                                                                \
+	t##name name = nullptr;
+
+namespace streamfx::nvidia::vfx {
+	typedef const char* effect_t;
+	typedef const char* parameter_t;
+	typedef void*       object_t;
+	typedef object_t    handle_t;
+
+	static constexpr effect_t EFFECT_TRANSFER           = "Transfer";
+	static constexpr effect_t EFFECT_GREEN_SCREEN       = "GreenScreen";
+	static constexpr effect_t EFFECT_BACKGROUND_BLUR    = "BackgroundBlur";
+	static constexpr effect_t EFFECT_ARTIFACT_REDUCTION = "ArtifactReduction";
+	static constexpr effect_t EFFECT_SUPERRESOLUTION    = "SuperRes";
+	static constexpr effect_t EFFECT_UPSCALE            = "Upscale";
+	static constexpr effect_t EFFECT_DENOISING          = "Denoising";
+
+	static constexpr parameter_t PARAMETER_INPUT_IMAGE_0   = "SrcImage0";
+	static constexpr parameter_t PARAMETER_INPUT_IMAGE_1   = "SrcImage1";
+	static constexpr parameter_t PARAMETER_OUTPUT_IMAGE_0  = "DstImage0";
+	static constexpr parameter_t PARAMETER_MODEL_DIRECTORY = "ModelDir";
+	static constexpr parameter_t PARAMETER_CUDA_STREAM     = "CudaStream";
+	static constexpr parameter_t PARAMETER_INFO            = "Info";
+	static constexpr parameter_t PARAMETER_SCALE           = "Scale";
+	static constexpr parameter_t PARAMETER_STRENGTH        = "Strength";
+	static constexpr parameter_t PARAMETER_STRENGTH_LEVELS = "StrengthLevels";
+	static constexpr parameter_t PARAMETER_MODE            = "Mode";
+	static constexpr parameter_t PARAMETER_TEMPORAL        = "Temporal";
+	static constexpr parameter_t PARAMETER_GPU             = "GPU";
+	static constexpr parameter_t PARAMETER_BATCH_SIZE      = "BatchSize";
+	static constexpr parameter_t PARAMETER_MODEL_BATCH     = "ModelBatch";
+	static constexpr parameter_t PARAMETER_STATE           = "State";
+	static constexpr parameter_t PARAMETER_STATE_SIZE      = "StateSize";
+
+	class vfx {
+		std::shared_ptr<::streamfx::util::library> _library;
+		std::filesystem::path                      _model_path;
+
+		public:
+		~vfx();
+		vfx();
+
+		std::filesystem::path model_path();
+
+		public:
+		NVVFX_DEFINE_FUNCTION(NvVFX_GetVersion, uint32_t* version);
+		NVVFX_DEFINE_FUNCTION(NvVFX_CreateEffect, effect_t effect, handle_t* handle);
+		NVVFX_DEFINE_FUNCTION(NvVFX_DestroyEffect, handle_t handle);
+		NVVFX_DEFINE_FUNCTION(NvVFX_SetU32, handle_t effect, parameter_t paramName, uint32_t val);
+		NVVFX_DEFINE_FUNCTION(NvVFX_SetS32, handle_t effect, parameter_t paramName, int32_t val);
+		NVVFX_DEFINE_FUNCTION(NvVFX_SetF32, handle_t effect, parameter_t paramName, float val);
+		NVVFX_DEFINE_FUNCTION(NvVFX_SetF64, handle_t effect, parameter_t paramName, double val);
+		NVVFX_DEFINE_FUNCTION(NvVFX_SetU64, handle_t effect, parameter_t paramName, uint64_t val);
+		NVVFX_DEFINE_FUNCTION(NvVFX_SetObject, handle_t effect, parameter_t paramName, void* ptr);
+		NVVFX_DEFINE_FUNCTION(NvVFX_SetCudaStream, handle_t effect, parameter_t paramName,
+							  ::streamfx::nvidia::cuda::stream_t stream);
+		NVVFX_DEFINE_FUNCTION(NvVFX_SetImage, handle_t effect, parameter_t paramName,
+							  ::streamfx::nvidia::cv::image_t* im);
+		NVVFX_DEFINE_FUNCTION(NvVFX_SetString, handle_t effect, parameter_t paramName, const char* str);
+		NVVFX_DEFINE_FUNCTION(NvVFX_GetU32, handle_t effect, parameter_t paramName, uint32_t* val);
+		NVVFX_DEFINE_FUNCTION(NvVFX_GetS32, handle_t effect, parameter_t paramName, int32_t* val);
+		NVVFX_DEFINE_FUNCTION(NvVFX_GetF32, handle_t effect, parameter_t paramName, float* val);
+		NVVFX_DEFINE_FUNCTION(NvVFX_GetF64, handle_t effect, parameter_t paramName, double* val);
+		NVVFX_DEFINE_FUNCTION(NvVFX_GetU64, handle_t effect, parameter_t paramName, uint64_t* val);
+		NVVFX_DEFINE_FUNCTION(NvVFX_GetObject, handle_t effect, parameter_t paramName, void** ptr);
+		NVVFX_DEFINE_FUNCTION(NvVFX_GetCudaStream, handle_t effect, parameter_t paramName,
+							  ::streamfx::nvidia::cuda::stream_t stream);
+		NVVFX_DEFINE_FUNCTION(NvVFX_GetImage, handle_t effect, parameter_t paramName,
+							  ::streamfx::nvidia::cv::image_t* im);
+		NVVFX_DEFINE_FUNCTION(NvVFX_GetString, handle_t effect, parameter_t paramName, const char** str);
+		NVVFX_DEFINE_FUNCTION(NvVFX_Run, handle_t effect, int32_t async);
+		NVVFX_DEFINE_FUNCTION(NvVFX_Load, handle_t effect);
+
+		public:
+		static std::shared_ptr<::streamfx::nvidia::vfx::vfx> get();
+	};
+} // namespace streamfx::nvidia::vfx

--- a/source/plugin.cpp
+++ b/source/plugin.cpp
@@ -56,6 +56,9 @@
 #ifdef ENABLE_FILTER_TRANSFORM
 #include "filters/filter-transform.hpp"
 #endif
+#ifdef ENABLE_FILTER_VIDEO_SUPERRESOLUTION
+#include "filters/filter-video-superresolution.hpp"
+#endif
 
 #ifdef ENABLE_SOURCE_MIRROR
 #include "sources/source-mirror.hpp"
@@ -153,6 +156,9 @@ try {
 #ifdef ENABLE_FILTER_TRANSFORM
 		streamfx::filter::transform::transform_factory::initialize();
 #endif
+#ifdef ENABLE_FILTER_VIDEO_SUPERRESOLUTION
+		streamfx::filter::video_superresolution::video_superresolution_factory::initialize();
+#endif
 	}
 
 	// Sources
@@ -235,6 +241,9 @@ try {
 #endif
 #ifdef ENABLE_FILTER_TRANSFORM
 		streamfx::filter::transform::transform_factory::finalize();
+#endif
+#ifdef ENABLE_FILTER_VIDEO_SUPERRESOLUTION
+		streamfx::filter::video_superresolution::video_superresolution_factory::finalize();
 #endif
 	}
 

--- a/source/util/util-profiler.cpp
+++ b/source/util/util-profiler.cpp
@@ -20,16 +20,16 @@
 #include "util-profiler.hpp"
 #include <iterator>
 
-util::profiler::profiler() {}
+streamfx::util::profiler::profiler() {}
 
-util::profiler::~profiler() {}
+streamfx::util::profiler::~profiler() {}
 
-std::shared_ptr<util::profiler::instance> util::profiler::track()
+std::shared_ptr<streamfx::util::profiler::instance> streamfx::util::profiler::track()
 {
-	return std::make_shared<util::profiler::instance>(shared_from_this());
+	return std::make_shared<streamfx::util::profiler::instance>(shared_from_this());
 }
 
-void util::profiler::track(std::chrono::nanoseconds duration)
+void streamfx::util::profiler::track(std::chrono::nanoseconds duration)
 {
 	std::unique_lock<std::mutex> ul(_timings_lock);
 	auto                         itr = _timings.find(duration);
@@ -40,7 +40,7 @@ void util::profiler::track(std::chrono::nanoseconds duration)
 	}
 }
 
-uint64_t util::profiler::count()
+uint64_t streamfx::util::profiler::count()
 {
 	uint64_t count = 0;
 
@@ -57,7 +57,7 @@ uint64_t util::profiler::count()
 	return count;
 }
 
-std::chrono::nanoseconds util::profiler::total_duration()
+std::chrono::nanoseconds streamfx::util::profiler::total_duration()
 {
 	std::chrono::nanoseconds duration{0};
 
@@ -74,7 +74,7 @@ std::chrono::nanoseconds util::profiler::total_duration()
 	return duration;
 }
 
-double_t util::profiler::average_duration()
+double_t streamfx::util::profiler::average_duration()
 {
 	std::chrono::nanoseconds duration{0};
 	uint64_t                 count = 0;
@@ -99,7 +99,7 @@ inline bool is_equal(T a, T b, T c)
 	return (a == b) || ((a >= (b - c)) && (a <= (b + c)));
 }
 
-std::chrono::nanoseconds util::profiler::percentile(double_t percentile, bool by_time)
+std::chrono::nanoseconds streamfx::util::profiler::percentile(double_t percentile, bool by_time)
 {
 	constexpr double_t edge  = 0.00005;
 	uint64_t           calls = count();
@@ -144,11 +144,11 @@ std::chrono::nanoseconds util::profiler::percentile(double_t percentile, bool by
 	return std::chrono::nanoseconds(-1);
 }
 
-util::profiler::instance::instance(std::shared_ptr<util::profiler> parent)
+streamfx::util::profiler::instance::instance(std::shared_ptr<streamfx::util::profiler> parent)
 	: _parent(parent), _start(std::chrono::high_resolution_clock::now())
 {}
 
-util::profiler::instance::~instance()
+streamfx::util::profiler::instance::~instance()
 {
 	auto end = std::chrono::high_resolution_clock::now();
 	auto dur = end - _start;
@@ -157,12 +157,12 @@ util::profiler::instance::~instance()
 	}
 }
 
-void util::profiler::instance::cancel()
+void streamfx::util::profiler::instance::cancel()
 {
 	_parent.reset();
 }
 
-void util::profiler::instance::reparent(std::shared_ptr<util::profiler> parent)
+void streamfx::util::profiler::instance::reparent(std::shared_ptr<streamfx::util::profiler> parent)
 {
 	_parent = parent;
 }

--- a/source/util/util-profiler.hpp
+++ b/source/util/util-profiler.hpp
@@ -23,8 +23,8 @@
 #include <map>
 #include <mutex>
 
-namespace util {
-	class profiler : public std::enable_shared_from_this<util::profiler> {
+namespace streamfx::util {
+	class profiler : public std::enable_shared_from_this<streamfx::util::profiler> {
 		std::map<std::chrono::nanoseconds, size_t> _timings;
 		std::mutex                                 _timings_lock;
 
@@ -49,7 +49,7 @@ namespace util {
 		public:
 		~profiler();
 
-		std::shared_ptr<class util::profiler::instance> track();
+		std::shared_ptr<class streamfx::util::profiler::instance> track();
 
 		void track(std::chrono::nanoseconds duration);
 
@@ -62,9 +62,9 @@ namespace util {
 		std::chrono::nanoseconds percentile(double_t percentile, bool by_time = false);
 
 		public:
-		static std::shared_ptr<util::profiler> create()
+		static std::shared_ptr<streamfx::util::profiler> create()
 		{
-			return std::shared_ptr<util::profiler>{new profiler()};
+			return std::shared_ptr<streamfx::util::profiler>{new profiler()};
 		}
 	};
-} // namespace util
+} // namespace streamfx::util

--- a/source/util/utility.hpp
+++ b/source/util/utility.hpp
@@ -182,6 +182,12 @@ namespace streamfx::util {
 		}
 
 		template<typename T>
+		inline bool is_close(T target, T value, T delta)
+		{
+			return (target > (value - delta)) && (target < (value + delta));
+		}
+
+		template<typename T>
 		inline std::vector<T> pascal_triangle(size_t n)
 		{
 			std::vector<T> line;


### PR DESCRIPTION
### Description
Adds/Implements the Video Super-Resolution filter which allows users with a supported upscaling provider to increase the resolution of their footage by up to 4x, while maintaining decent quality. This comes at some VRAM and GPU time cost, but it can make a 1280x720 camera look like a 3K camera.

At the current moment, only the following super resolution providers exist:

- NVIDIA Video Super-Resolution

### Related Issues
