### PR TITLE
Fix some parts of CUDA interaction code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -975,6 +975,9 @@ if(HAVE_NVIDIA_CUDA)
 		"source/nvidia/cuda/nvidia-cuda-stream.hpp"
 		"source/nvidia/cuda/nvidia-cuda-stream.cpp"
 	)
+	list(APPEND PROJECT_DEFINITIONS
+		ENABLE_NVIDIA_CUDA
+	)
 endif()
 
 if(REQUIRE_OBSFE AND HAVE_OBSFE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1005,6 +1005,8 @@ list(APPEND PROJECT_PRIVATE_SOURCE
 	"source/util/util-library.hpp"
 	"source/util/util-logging.cpp"
 	"source/util/util-logging.hpp"
+	"source/util/util-platform.hpp"
+	"source/util/util-platform.cpp"
 	"source/util/util-threadpool.cpp"
 	"source/util/util-threadpool.hpp"
 	"source/gfx/gfx-source-texture.hpp"

--- a/source/nvidia/cuda/nvidia-cuda-context.cpp
+++ b/source/nvidia/cuda/nvidia-cuda-context.cpp
@@ -90,6 +90,29 @@ streamfx::nvidia::cuda::context::context(ID3D11Device* device) : context()
 		throw std::runtime_error("Failed to acquire primary device context.");
 	}
 
+	// Log some information.
+	std::string device_name;
+	uuid_t      device_uuid;
+	luid_t      device_luid;
+	uint32_t    device_luid_mask;
+	{
+		// Device Name
+		std::vector<char> name(256, 0);
+		_cuda->cuDeviceGetName(name.data(), name.size() - 1, _device);
+		device_name = std::string(name.data(), name.data() + strlen(name.data()));
+
+		// Device LUID
+		_cuda->cuDeviceGetLuid(&device_luid, &device_luid_mask, _device);
+
+		// Device UUID
+		_cuda->cuDeviceGetUuid(&device_uuid, _device);
+	}
+
+	D_LOG_INFO("Initialized CUDA on device '%s' (%08" PRIx32 "-%04" PRIx16 "-%04" PRIx16 "-%04" PRIx16 "-%04" PRIx16
+			   "%08" PRIx32 ", %08" PRIx64 ", %" PRIu32 ").",
+			   device_name.c_str(), device_uuid.uuid.a, device_uuid.uuid.b, device_uuid.uuid.c, device_uuid.uuid.d,
+			   device_uuid.uuid.e, device_uuid.uuid.f, device_luid.luid, device_luid_mask);
+
 	_has_device = true;
 }
 #endif

--- a/source/nvidia/cuda/nvidia-cuda-context.cpp
+++ b/source/nvidia/cuda/nvidia-cuda-context.cpp
@@ -55,8 +55,9 @@ streamfx::nvidia::cuda::context::~context()
 
 	if (_has_device) {
 		_cuda->cuDevicePrimaryCtxRelease(_device);
+	} else {
+		_cuda->cuCtxDestroy(_ctx);
 	}
-	_cuda->cuCtxDestroy(_ctx);
 }
 
 streamfx::nvidia::cuda::context::context()
@@ -84,6 +85,8 @@ streamfx::nvidia::cuda::context::context(ID3D11Device* device) : context()
 	if (result res = _cuda->cuD3D11GetDevice(&_device, dxgi_adapter); res != result::SUCCESS) {
 		throw std::runtime_error("Failed to get device index for device.");
 	}
+
+	_cuda->cuDevicePrimaryCtxSetFlags(_device, context_flags::SCHEDULER_BLOCKING_SYNC);
 
 	// Acquire Context
 	if (result res = _cuda->cuDevicePrimaryCtxRetain(&_ctx, _device); res != result::SUCCESS) {

--- a/source/nvidia/cuda/nvidia-cuda-obs.cpp
+++ b/source/nvidia/cuda/nvidia-cuda-obs.cpp
@@ -44,6 +44,7 @@ streamfx::nvidia::cuda::obs::~obs()
 		auto stack = _context->enter();
 		_stream->synchronize();
 		_context->synchronize();
+		_stream.reset();
 	}
 	_context.reset();
 	_cuda.reset();

--- a/source/nvidia/cuda/nvidia-cuda.cpp
+++ b/source/nvidia/cuda/nvidia-cuda.cpp
@@ -114,7 +114,9 @@ streamfx::nvidia::cuda::cuda::cuda() : _library()
 
 	{ // 3. Load remaining functions.
 		// Device Management
-		// - Not yet needed.
+		P_CUDA_LOAD_SYMBOL(cuDeviceGetName);
+		P_CUDA_LOAD_SYMBOL(cuDeviceGetLuid);
+		P_CUDA_LOAD_SYMBOL(cuDeviceGetUuid);
 
 		// Primary Context Management
 		P_CUDA_LOAD_SYMBOL(cuDevicePrimaryCtxRetain);

--- a/source/nvidia/cuda/nvidia-cuda.hpp
+++ b/source/nvidia/cuda/nvidia-cuda.hpp
@@ -162,6 +162,31 @@ namespace streamfx::nvidia::cuda {
 		uint32_t reserved[16];
 	};
 
+	struct uuid_t {
+		union {
+			char bytes[16];
+			struct {
+				uint32_t a;
+				uint16_t b;
+				uint16_t c;
+				uint16_t d;
+				uint16_t e;
+				uint32_t f;
+			} uuid;
+		};
+	};
+
+	struct luid_t {
+		union {
+			char bytes[8];
+			struct {
+				uint32_t low;
+				int32_t  high;
+			} parts;
+			uint64_t luid;
+		};
+	};
+
 	class cuda_error : public std::exception {
 		::streamfx::nvidia::cuda::result _code;
 
@@ -192,6 +217,9 @@ namespace streamfx::nvidia::cuda {
 		P_CUDA_DEFINE_FUNCTION(cuDriverGetVersion, int32_t* driverVersion);
 
 		// Device Management
+		P_CUDA_DEFINE_FUNCTION(cuDeviceGetName, char* name, int32_t length, device_t device);
+		P_CUDA_DEFINE_FUNCTION(cuDeviceGetLuid, luid_t* luid, uint32_t* device_node_mask, device_t device);
+		P_CUDA_DEFINE_FUNCTION(cuDeviceGetUuid, uuid_t* uuid, device_t device);
 		// - Not yet needed.
 
 		// Primary Context Management

--- a/source/plugin.cpp
+++ b/source/plugin.cpp
@@ -24,6 +24,10 @@
 #include "obs/gs/gs-vertexbuffer.hpp"
 #include "obs/obs-source-tracker.hpp"
 
+#ifdef ENABLE_NVIDIA_CUDA
+#include "nvidia/cuda/nvidia-cuda-obs.hpp"
+#endif
+
 #ifdef ENABLE_ENCODER_FFMPEG
 #include "encoders/encoder-ffmpeg.hpp"
 #endif
@@ -88,6 +92,11 @@ try {
 
 	// Initialize Source Tracker
 	streamfx::obs::source_tracker::initialize();
+
+#ifdef ENABLE_NVIDIA_CUDA
+	// Initialize CUDA if features requested it.
+	auto cuda = ::streamfx::nvidia::cuda::obs::get();
+#endif
 
 	// GS Stuff
 	{

--- a/source/util/util-library.cpp
+++ b/source/util/util-library.cpp
@@ -20,6 +20,7 @@
 
 #include "util-library.hpp"
 #include <unordered_map>
+#include "util-platform.hpp"
 
 #if defined(_WIN32) || defined(_WIN64) || defined(__CYGWIN__) // Windows
 #define ST_WINDOWS
@@ -37,6 +38,7 @@ streamfx::util::library::library(std::filesystem::path file) : _library(nullptr)
 {
 #if defined(ST_WINDOWS)
 	SetLastError(ERROR_SUCCESS);
+	file     = ::streamfx::util::platform::utf8_to_native(file);
 	_library = reinterpret_cast<void*>(LoadLibraryW(file.wstring().c_str()));
 	if (!_library) {
 		DWORD error = GetLastError();

--- a/source/util/util-platform.cpp
+++ b/source/util/util-platform.cpp
@@ -1,0 +1,86 @@
+// Copyright 2020 Michael Fabian 'Xaymar' Dirks <info@xaymar.com>
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+// IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+// INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+// OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+// OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "util-platform.hpp"
+#include "util-logging.hpp"
+
+#ifdef _DEBUG
+#define ST_PREFIX "<%s> "
+#define D_LOG_ERROR(x, ...) P_LOG_ERROR(ST_PREFIX##x, __FUNCTION_SIG__, __VA_ARGS__)
+#define D_LOG_WARNING(x, ...) P_LOG_WARN(ST_PREFIX##x, __FUNCTION_SIG__, __VA_ARGS__)
+#define D_LOG_INFO(x, ...) P_LOG_INFO(ST_PREFIX##x, __FUNCTION_SIG__, __VA_ARGS__)
+#define D_LOG_DEBUG(x, ...) P_LOG_DEBUG(ST_PREFIX##x, __FUNCTION_SIG__, __VA_ARGS__)
+#else
+#define ST_PREFIX "<util::platform> "
+#define D_LOG_ERROR(...) P_LOG_ERROR(ST_PREFIX __VA_ARGS__)
+#define D_LOG_WARNING(...) P_LOG_WARN(ST_PREFIX __VA_ARGS__)
+#define D_LOG_INFO(...) P_LOG_INFO(ST_PREFIX __VA_ARGS__)
+#define D_LOG_DEBUG(...) P_LOG_DEBUG(ST_PREFIX __VA_ARGS__)
+#endif
+
+#ifdef WIN32
+#include <Windows.h>
+
+std::string streamfx::util::platform::native_to_utf8(std::wstring const& v)
+{
+	std::vector<char> buffer((v.length() + 1) * 4, 0);
+
+	DWORD res = WideCharToMultiByte(CP_UTF8, 0, v.c_str(), static_cast<int>(v.length()), buffer.data(),
+									static_cast<int>(buffer.size()), nullptr, nullptr);
+	if (res == 0) {
+		D_LOG_WARNING("Failed to convert '%ls' to UTF-8 format.", v.c_str());
+		throw std::runtime_error("Failed to convert Windows-native to UTF-8.");
+	}
+
+	return {buffer.data()};
+}
+
+std::filesystem::path streamfx::util::platform::native_to_utf8(std::filesystem::path const& v)
+{
+	auto wide   = v.wstring();
+	auto narrow = native_to_utf8(wide);
+	return std::filesystem::u8path(narrow);
+}
+
+std::wstring streamfx::util::platform::utf8_to_native(std::string const& v)
+{
+	std::vector<wchar_t> buffer(v.length() + 1, 0);
+
+	DWORD res = MultiByteToWideChar(CP_UTF8, 0, v.c_str(), static_cast<int>(v.length()), buffer.data(),
+									static_cast<int>(buffer.size()));
+	if (res == 0) {
+		D_LOG_WARNING("Failed to convert '%s' to native format.", v.c_str());
+		throw std::runtime_error("Failed to convert UTF-8 to Windows-native.");
+	}
+
+	return {buffer.data()};
+}
+
+std::filesystem::path streamfx::util::platform::utf8_to_native(std::filesystem::path const& v)
+{
+	auto narrow = v.string();
+	auto wide   = utf8_to_native(narrow);
+	return std::filesystem::path(wide);
+}
+
+#endif

--- a/source/util/util-platform.hpp
+++ b/source/util/util-platform.hpp
@@ -1,0 +1,54 @@
+// Copyright 2020 Michael Fabian 'Xaymar' Dirks <info@xaymar.com>
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+// IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+// INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+// OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+// OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#pragma once
+#include <filesystem>
+#include <string>
+
+namespace streamfx::util::platform {
+#ifdef WIN32
+	std::string           native_to_utf8(std::wstring const& v);
+	std::filesystem::path native_to_utf8(std::filesystem::path const& v);
+
+	std::wstring          utf8_to_native(std::string const& v);
+	std::filesystem::path utf8_to_native(std::filesystem::path const& v);
+#else
+	inline std::string native_to_utf8(std::string const& v)
+	{
+		return std::string(v);
+	};
+	inline std::filesystem::path native_to_utf8(std::filesystem::path const& v)
+	{
+		return std::filesystem::path(v);
+	};
+
+	inline std::string utf8_to_native(std::string const& v)
+	{
+		return std::string(v);
+	};
+	inline std::filesystem::path utf8_to_native(std::filesystem::path const& v)
+	{
+		return std::filesystem::path(v);
+	};
+#endif
+} // namespace streamfx::util::platform


### PR DESCRIPTION
### Explain the Pull Request
- CUDA and related information should be loaded as soon as possible, instead of on-demand.
- The primary context should not be destroyed by StreamFX.
- The stream has to be released _before_ the context is released.
- Some additional logging for the device information is nice to have.
<!-- Describe the PR in as much detail as possible, leave nothing out. -->
<!-- If you think images or example videos help describe the PR, include them. -->

### Why is this necessary?
<!-- What makes this PR necessary for StreamFX and it's users? -->

### Checklist
- [x] I will become the maintainer for this part of code.
- [x] I have tested this code on all supported Platforms.

### Related Issues
<!-- Is this PR related to another PR or Issue? List them here. -->
<!-- - #0000 Name of Issue -->
<!-- - #0001 Name of Issue -->
