### PR TITLE
Fixes and Enhancements for Video Super-Resolution filter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -693,7 +693,7 @@ function(feature_filter_video_superresolution RESOLVE)
 		endif()
 
 		# Verify that we have at least one provider for Video Super-Resolution.
-		is_feature_enabled(FILTER_VIDEO_SUPERRESOLUTION T_CHECK_NVIDIA)
+		is_feature_enabled(FILTER_VIDEO_SUPERRESOLUTION_NVIDIA T_CHECK_NVIDIA)
 		if (NOT T_CHECK_NVIDIA)
 			message(WARNING "${LOGPREFIX}: Video Super-Resolution has no available providers. Disabling...")
 			set_feature_disabled(FILTER_VIDEO_SUPERRESOLUTION ON)

--- a/source/nvidia/cv/nvidia-cv-image.cpp
+++ b/source/nvidia/cv/nvidia-cv-image.cpp
@@ -51,7 +51,7 @@ image::~image()
 	_cv->NvCVImage_Dealloc(&_image);
 }
 
-image::image() : _cv(::streamfx::nvidia::cv::cv::get()), _image()
+image::image() : _cv(::streamfx::nvidia::cv::cv::get()), _image(), _alignment(1)
 {
 	// Forcefully clear the image storage.
 	memset(&_image, sizeof(_image), 0);
@@ -64,8 +64,9 @@ image::image(uint32_t width, uint32_t height, pixel_format pix_fmt, component_ty
 	auto gctx = ::streamfx::obs::gs::context();
 	auto cctx = ::streamfx::nvidia::cuda::obs::get()->get_context()->enter();
 
+	_alignment = alignment;
 	if (auto res = _cv->NvCVImage_Alloc(&_image, width, height, pix_fmt, cmp_type, static_cast<uint32_t>(cmp_layout),
-										static_cast<uint32_t>(location), alignment);
+										static_cast<uint32_t>(location), _alignment);
 		res != result::SUCCESS) {
 		throw std::runtime_error(_cv->NvCV_GetErrorStringFromCode(res));
 	}
@@ -83,13 +84,13 @@ void streamfx::nvidia::cv::image::reallocate(uint32_t width, uint32_t height, pi
 		res != result::SUCCESS) {
 		throw std::runtime_error(_cv->NvCV_GetErrorStringFromCode(res));
 	}
+	_alignment = alignment;
 }
 
 void streamfx::nvidia::cv::image::resize(uint32_t width, uint32_t height)
 {
-	// TODO: Is pixel_bytes correct?
 	reallocate(width, height, _image.pxl_format, _image.comp_type, static_cast<component_layout>(_image.comp_layout),
-			   static_cast<memory_location>(_image.mem_location), _image.pixel_bytes);
+			   static_cast<memory_location>(_image.mem_location), _alignment);
 }
 
 streamfx::nvidia::cv::image_t* streamfx::nvidia::cv::image::get_image()

--- a/source/nvidia/cv/nvidia-cv-image.hpp
+++ b/source/nvidia/cv/nvidia-cv-image.hpp
@@ -32,6 +32,7 @@ namespace streamfx::nvidia::cv {
 		protected:
 		std::shared_ptr<::streamfx::nvidia::cv::cv> _cv;
 		image_t                                     _image;
+		size_t                                      _alignment;
 
 		public:
 		virtual ~image();

--- a/source/nvidia/cv/nvidia-cv-texture.cpp
+++ b/source/nvidia/cv/nvidia-cv-texture.cpp
@@ -119,9 +119,5 @@ void streamfx::nvidia::cv::texture::free()
 					_cv->NvCV_GetErrorStringFromCode(res));
 		throw std::runtime_error("NvCVImage_UnmapResource");
 	}
-	if (auto res = _cv->NvCVImage_Dealloc(&_image); res != result::SUCCESS) {
-		D_LOG_ERROR("Object 0x%" PRIxPTR " failed NvCVImage_Dealloc call with error: %s", this,
-					_cv->NvCV_GetErrorStringFromCode(res));
-		throw std::runtime_error("NvCVImage_Dealloc");
-	}
+	_cv->NvCVImage_Dealloc(&_image);
 }

--- a/source/nvidia/cv/nvidia-cv.hpp
+++ b/source/nvidia/cv/nvidia-cv.hpp
@@ -226,7 +226,7 @@ namespace streamfx::nvidia::cv {
 		NVCVI_DEFINE_FUNCTION(NvCVImage_Realloc, image_t* image, uint32_t width, uint32_t height, pixel_format format,
 							  component_type comp_type, uint32_t comp_layout, uint32_t mem_location,
 							  uint32_t alignment);
-		NVCVI_DEFINE_FUNCTION(NvCVImage_Dealloc, image_t* image);
+		NVCVI_DEFINE_FUNCTION_EX(void, NvCVImage_Dealloc, image_t* image);
 		NVCVI_DEFINE_FUNCTION(NvCVImage_Create, uint32_t width, uint32_t height, pixel_format format,
 							  component_type comp_type, component_layout comp_layout, memory_location mem_location,
 							  uint32_t alignment, image_t** image);

--- a/source/nvidia/vfx/nvidia-vfx-superresolution.cpp
+++ b/source/nvidia/vfx/nvidia-vfx-superresolution.cpp
@@ -329,10 +329,7 @@ void streamfx::nvidia::vfx::superresolution::resize(uint32_t width, uint32_t hei
 		}
 
 		if (_convert_to_fp32) {
-			_convert_to_fp32->reallocate(out_width, out_height, ::streamfx::nvidia::cv::pixel_format::RGBA,
-										 ::streamfx::nvidia::cv::component_type::FP32,
-										 ::streamfx::nvidia::cv::component_layout::PLANAR,
-										 ::streamfx::nvidia::cv::memory_location::GPU, 1);
+			_convert_to_fp32->resize(out_width, out_height);
 		} else {
 			_convert_to_fp32 = std::make_shared<::streamfx::nvidia::cv::image>(
 				out_width, out_height, ::streamfx::nvidia::cv::pixel_format::RGBA,
@@ -369,10 +366,7 @@ void streamfx::nvidia::vfx::superresolution::resize(uint32_t width, uint32_t hei
 		}
 
 		if (_convert_to_u8) {
-			_convert_to_u8->reallocate(out_width, out_height, ::streamfx::nvidia::cv::pixel_format::RGBA,
-									   ::streamfx::nvidia::cv::component_type::UINT8,
-									   ::streamfx::nvidia::cv::component_layout::INTERLEAVED,
-									   ::streamfx::nvidia::cv::memory_location::GPU, 1);
+			_convert_to_u8->resize(out_width, out_height);
 		} else {
 			_convert_to_u8 = std::make_shared<::streamfx::nvidia::cv::image>(
 				out_width, out_height, ::streamfx::nvidia::cv::pixel_format::RGBA,


### PR DESCRIPTION
### Explain the Pull Request
1. The CMake file didn't check if any provider was actually available, instead it checked for itself. With this patch it should now disable if no providers are enabled.
2. The function NvCVImage_Dealloc returns void, but was incorrectly treated as if it returned NvCVStatus.
3. `::streamfx::nvidia::cv::image` needs to store the alignment used for resize() calls, as otherwise we end up with very weird misalignments and driver crashes.
4. The Super-Resolution wrapper should use resize instead of reallocate, now that the function has been fixed.

### Why is this necessary?
There are a few cases where Video Super-Resolution crashes or results in a driver reset, which is not what users want to see. 
<!-- What makes this PR necessary for StreamFX and it's users? -->

### Checklist
- [x] I will become the maintainer for this part of code.
- [x] I have tested this code on all supported Platforms.

### Related Issues
<!-- Is this PR related to another PR or Issue? List them here. -->
<!-- - #0000 Name of Issue -->
<!-- - #0001 Name of Issue -->
