### PR TITLE
plugin: Don't leak CUDA load exceptions

### DIFF
--- a/source/plugin.cpp
+++ b/source/plugin.cpp
@@ -98,7 +98,12 @@ try {
 
 #ifdef ENABLE_NVIDIA_CUDA
 	// Initialize CUDA if features requested it.
-	auto cuda = ::streamfx::nvidia::cuda::obs::get();
+	std::shared_ptr<::streamfx::nvidia::cuda::obs> cuda;
+	try {
+		cuda = ::streamfx::nvidia::cuda::obs::get();
+	} catch (...) {
+		// If CUDA failed to load, it is considered safe to ignore.
+	}
 #endif
 
 	// GS Stuff
@@ -185,6 +190,9 @@ try {
 
 	DLOG_INFO("Loaded Version %s", STREAMFX_VERSION_STRING);
 	return true;
+} catch (std::exception const& ex) {
+	DLOG_ERROR("Unexpected exception in function '%s': %s", __FUNCTION_NAME__, ex.what());
+	return false;
 } catch (...) {
 	DLOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
 	return false;
@@ -274,6 +282,8 @@ try {
 	streamfx::configuration::finalize();
 
 	DLOG_INFO("Unloaded Version %s", STREAMFX_VERSION_STRING);
+} catch (std::exception const& ex) {
+	DLOG_ERROR("Unexpected exception in function '%s': %s", __FUNCTION_NAME__, ex.what());
 } catch (...) {
 	DLOG_ERROR("Unexpected exception in function '%s'.", __FUNCTION_NAME__);
 }


### PR DESCRIPTION
### Explain the Pull Request
Fixes a failure to load the plugin if the GPU is not an NVIDIA GPU or the Driver is outdated.
<!-- Describe the PR in as much detail as possible, leave nothing out. -->
<!-- If you think images or example videos help describe the PR, include them. -->

### Why is this necessary?
People want to use the Testing versions in Production, no matter how often I tell people not to.
<!-- What makes this PR necessary for StreamFX and it's users? -->

### Checklist
- [x] I will become the maintainer for this part of code.
- [x] I have tested this code on all supported Platforms.

### Related Issues
<!-- Is this PR related to another PR or Issue? List them here. -->
<!-- - #0000 Name of Issue -->
<!-- - #0001 Name of Issue -->
