### PR TITLE
Avoid vargs reuse

### DIFF
--- a/source/util/util-logging.cpp
+++ b/source/util/util-logging.cpp
@@ -34,11 +34,14 @@ void streamfx::util::logging::log(level lvl, const char* format, ...)
 	va_list vargs;
 	va_start(vargs, format);
 
+	va_list vargs_copy;
+	va_copy(vargs_copy, vargs);
 	int32_t ret = vsnprintf(buffer.data(), buffer.size(), format, vargs);
 	buffer.resize(ret + 1);
-	ret = vsnprintf(buffer.data(), buffer.size(), format, vargs);
+	ret = vsnprintf(buffer.data(), buffer.size(), format, vargs_copy);
 
 	va_end(vargs);
+	va_end(vargs_copy);
 
 	blog(level_map.at(lvl), "[StreamFX] %s", buffer.data());
 }


### PR DESCRIPTION
### Explain the Pull Request
vsnprintf is allowed to modify vargs, and at least GCC under Linux does
modify it, causing a segfault on any log call.

This creates a duplicate vargs to avoid this issue.


### Why is this necessary?
It fixes a bug

### Checklist
- [ X ] I will become the maintainer for this part of code.
- [  ] I have tested this code on all supported Platforms.

I only have one platform available to me.

### Related Issues

Relates to #630 New Unified logging causes crash on start under Linux/Gentoo
Closes: #630