### PR TITLE
ci: Pull Requests shouldn't invoke CI twice

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,10 +2,10 @@ name: Build
 
 on:
   push:
+    branches:
+      - 'master'
     tags:
       - '*'
-    branches-ignore:
-      - 'l10n_master'
   pull_request:
     branches:
       - '*'


### PR DESCRIPTION
### Explain the Pull Request
Prevents CI from running twice for pull requests coming from the same repository.
<!-- Describe the PR in as much detail as possible, leave nothing out. -->
<!-- If you think images or example videos help describe the PR, include them. -->

### Why is this necessary?
CI was getting overloaded with double the workload every time there was a small change to a PR from this repo.
<!-- What makes this PR necessary for StreamFX and it's users? -->

### Checklist
- [x] I will become the maintainer for this part of code.
- [ ] I have tested this code on all supported Platforms.

### Related Issues
<!-- Is this PR related to another PR or Issue? List them here. -->
<!-- - #0000 Name of Issue -->
<!-- - #0001 Name of Issue -->
