### PR TITLE
Automatically select ideal scale factors in Upscaling filter

### DIFF
--- a/source/nvidia/vfx/nvidia-vfx-superresolution.hpp
+++ b/source/nvidia/vfx/nvidia-vfx-superresolution.hpp
@@ -47,6 +47,10 @@ namespace streamfx::nvidia::vfx {
 
 		bool _dirty;
 
+		std::pair<uint32_t, uint32_t> _cache_input_size;
+		std::pair<uint32_t, uint32_t> _cache_output_size;
+		float                         _cache_scale;
+
 		public:
 		~superresolution();
 		superresolution();


### PR DESCRIPTION
### Explain the Pull Request
Prevents some scale factors from breaking down completely by automatically detecting the minimum ideal scaling factor that can be used at the resolution.
<!-- Describe the PR in as much detail as possible, leave nothing out. -->
<!-- If you think images or example videos help describe the PR, include them. -->

### Why is this necessary?
Users might not like having to actually understand how to use the things they're given.
<!-- What makes this PR necessary for StreamFX and it's users? -->

### Checklist
- [ ] I will become the maintainer for this part of code.
- [ ] I have tested this code on all supported Platforms.

### Related Issues
<!-- Is this PR related to another PR or Issue? List them here. -->
<!-- - #0000 Name of Issue -->
<!-- - #0001 Name of Issue -->
