### PR TITLE
util/library: Don't mix incompatible parameters

### DIFF
--- a/source/util/util-library.cpp
+++ b/source/util/util-library.cpp
@@ -39,8 +39,11 @@ streamfx::util::library::library(std::filesystem::path file) : _library(nullptr)
 #if defined(ST_WINDOWS)
 	SetLastError(ERROR_SUCCESS);
 	auto wfile = ::streamfx::util::platform::utf8_to_native(file.u8string());
-	_library   = reinterpret_cast<void*>(
-        LoadLibraryExW(wfile.c_str(), nullptr, LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR | LOAD_LIBRARY_SEARCH_DEFAULT_DIRS));
+	if (file.is_absolute()) {
+		_library = reinterpret_cast<void*>(LoadLibraryExW(wfile.c_str(), nullptr, LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR));
+	} else {
+		_library = reinterpret_cast<void*>(LoadLibraryExW(wfile.c_str(), nullptr, LOAD_LIBRARY_SEARCH_DEFAULT_DIRS));
+	}
 	if (!_library) {
 		DWORD error = GetLastError();
 		if (error != ERROR_PROC_NOT_FOUND) {


### PR DESCRIPTION
### Explain the Pull Request
LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR requires an absolute path, and does not work with relative paths, LOAD_LIBRARY_SEARCH_DEFAULT_DIRS is the opposite.
<!-- Describe the PR in as much detail as possible, leave nothing out. -->
<!-- If you think images or example videos help describe the PR, include them. -->

### Why is this necessary?
Makes things load on Windows again.
<!-- What makes this PR necessary for StreamFX and it's users? -->

### Checklist
- [x] I will become the maintainer for this part of code.
- [x] I have tested this code on all supported Platforms.

### Related Issues
<!-- Is this PR related to another PR or Issue? List them here. -->
<!-- - #0000 Name of Issue -->
<!-- - #0001 Name of Issue -->
