### PR TITLE
Fix Effect integration

### DIFF
--- a/data/effects/lut.effect
+++ b/data/effects/lut.effect
@@ -36,7 +36,7 @@ float4 generate_lut2(float2 uv, uint4 params0) {
 	);
 };
 
-float3 sample_lut(float3 color, uint bit_depth, texture2D lut_texture) {
+float3 sample_lut(float3 color, uint bit_depth, texture2d lut_texture) {
 	uint size = pow(2, bit_depth);
 	uint z_size = pow(2, bit_depth / 2);
 	uint container_size = pow(2, bit_depth + (bit_depth / 2));
@@ -82,7 +82,7 @@ float3 sample_lut(float3 color, uint bit_depth, texture2D lut_texture) {
 	return lerp(c_lo, c_hi, frac(color.z));
 };
 
-float3 sample_lut2(float3 color, texture2D lut_texture, int4 params0, float4 params1) {
+float3 sample_lut2(float3 color, texture2d lut_texture, int4 params0, float4 params1) {
 	uint size = params0.r;
 	uint z_size = params0.g;
 	uint container_size = params0.b;

--- a/data/effects/shared.effect
+++ b/data/effects/shared.effect
@@ -50,6 +50,7 @@ struct VertexData {
 	float4 pos : POSITION;
 	float2 uv  : TEXCOORD0;
 };
+
 struct VertexColorData {
 	float4 pos : POSITION;
 	float4 clr : COLOR;
@@ -63,6 +64,7 @@ VertexData DefaultVertexShader(VertexData vtx) {
 	vtx.pos = mul(float4(vtx.pos.xyz, 1.0), ViewProj);
 	return vtx;
 };
+
 VertexColorData ColorVertexShader(VertexColorData vtx) {
 	vtx.pos = mul(float4(vtx.pos.xyz, 1.0), ViewProj);
 	return vtx;

--- a/data/effects/standard.effect
+++ b/data/effects/standard.effect
@@ -1,9 +1,10 @@
 #include "shared.effect"
 
-uniform texture2D InputA<
+uniform texture2d InputA<
 	bool automatic = true;
 >;
-uniform texture2D InputB<
+
+uniform texture2d InputB<
 	bool automatic = true;
 >;
 

--- a/data/effects/transform.effect
+++ b/data/effects/transform.effect
@@ -1,6 +1,6 @@
 #include "shared.effect"
 
-uniform texture2D InputA<
+uniform texture2d InputA<
 	bool automatic = true;
 >;
 
@@ -58,7 +58,7 @@ uniform float2 CornerBR<
 // - CornerBL: Corner "D"
 // - CornerBR: Corner "C"
 
-float2 cross2d(in float2 a, in float2 b) {
+float cross2d(in float2 a, in float2 b) {
 	return (a.x * b.y) - (a.y * b.x);
 };
 

--- a/data/effects/virtual-greenscreen.effect
+++ b/data/effects/virtual-greenscreen.effect
@@ -1,9 +1,9 @@
 #include "shared.effect"
 
-uniform texture2D InputA<
+uniform texture2d InputA<
 	bool automatic = true;
 >;
-uniform texture2D InputB<
+uniform texture2d InputB<
 	bool automatic = true;
 >;
 uniform float Threshold<

--- a/source/filters/filter-blur.cpp
+++ b/source/filters/filter-blur.cpp
@@ -153,11 +153,11 @@ blur_instance::blur_instance(obs_data_t* settings, obs_source_t* self)
 
 		// Load Effects
 		{
-			auto file = streamfx::data_file_path("effects/mask.effect").string();
+			auto file = streamfx::data_file_path("effects/mask.effect");
 			try {
 				_effect_mask = streamfx::obs::gs::effect::create(file);
-			} catch (std::runtime_error& ex) {
-				DLOG_ERROR("<filter-blur> Loading effect '%s' failed with error(s): %s", file.c_str(), ex.what());
+			} catch (std::exception& ex) {
+				DLOG_ERROR("Error loading '%s': %s", file.generic_u8string().c_str(), ex.what());
 			}
 		}
 	}

--- a/source/filters/filter-displacement.cpp
+++ b/source/filters/filter-displacement.cpp
@@ -51,7 +51,19 @@ using namespace streamfx::filter::displacement;
 displacement_instance::displacement_instance(obs_data_t* data, obs_source_t* context)
 	: obs::source_instance(data, context)
 {
-	_effect = streamfx::obs::gs::effect::create(streamfx::data_file_path("effects/displace.effect").u8string());
+	{
+		auto gctx = streamfx::obs::gs::context();
+
+		{
+			auto file = streamfx::data_file_path("effects/displace.effect");
+			try {
+				_effect = streamfx::obs::gs::effect::create(file);
+			} catch (std::exception& ex) {
+				D_LOG_ERROR("Error loading '%s': %s", file.u8string().c_str(), ex.what());
+				throw;
+			}
+		}
+	}
 
 	update(data);
 }

--- a/source/filters/filter-dynamic-mask.cpp
+++ b/source/filters/filter-dynamic-mask.cpp
@@ -77,13 +77,21 @@ dynamic_mask_instance::dynamic_mask_instance(obs_data_t* settings, obs_source_t*
 	  _filter_texture(), _have_input_texture(false), _input(), _input_capture(), _input_texture(),
 	  _have_final_texture(false), _final_rt(), _final_texture(), _channels(), _precalc()
 {
-	_filter_rt = std::make_shared<streamfx::obs::gs::rendertarget>(GS_RGBA, GS_ZS_NONE);
-	_final_rt  = std::make_shared<streamfx::obs::gs::rendertarget>(GS_RGBA, GS_ZS_NONE);
+	{
+		auto gctx = streamfx::obs::gs::context();
 
-	try {
-		_effect = streamfx::obs::gs::effect::create(streamfx::data_file_path("effects/channel-mask.effect").u8string());
-	} catch (const std::exception& ex) {
-		DLOG_ERROR("Loading channel mask effect failed with error(s):\n%s", ex.what());
+		_filter_rt = std::make_shared<streamfx::obs::gs::rendertarget>(GS_RGBA, GS_ZS_NONE);
+		_final_rt  = std::make_shared<streamfx::obs::gs::rendertarget>(GS_RGBA, GS_ZS_NONE);
+
+		{
+			auto file = streamfx::data_file_path("effects/channel-mask.effect");
+			try {
+				_effect = streamfx::obs::gs::effect::create(file);
+			} catch (std::exception& ex) {
+				D_LOG_ERROR("Error loading '%s': %s", file.u8string().c_str(), ex.what());
+				throw;
+			}
+		}
 	}
 
 	update(settings);

--- a/source/filters/filter-sdf-effects.cpp
+++ b/source/filters/filter-sdf-effects.cpp
@@ -145,12 +145,12 @@ sdf_effects_instance::sdf_effects_instance(obs_data_t* settings, obs_source_t* s
 			{"effects/sdf/sdf-consumer.effect", _sdf_consumer_effect},
 		};
 		for (auto& kv : load_arr) {
-			auto path = streamfx::data_file_path(kv.first).u8string();
+			auto file = streamfx::data_file_path(kv.first);
 			try {
-				kv.second = streamfx::obs::gs::effect::create(path);
-			} catch (const std::exception& ex) {
-				D_LOG_ERROR("Failed to load effect '%s' (located at '%s') with error(s): %s", kv.first, path.c_str(),
-							ex.what());
+				kv.second = streamfx::obs::gs::effect::create(file);
+			} catch (std::exception& ex) {
+				D_LOG_ERROR("Error loading '%s': %s", file.u8string().c_str(), ex.what());
+				throw;
 			}
 		}
 	}

--- a/source/filters/filter-transform.cpp
+++ b/source/filters/filter-transform.cpp
@@ -114,42 +114,46 @@ transform_instance::transform_instance(obs_data_t* data, obs_source_t* context)
 	  _sampler(), _params(), _corners(), _cache_rendered(), _mipmap_enabled(), _source_rendered(), _source_size(),
 	  _update_mesh(true)
 {
-	_cache_rt      = std::make_shared<streamfx::obs::gs::rendertarget>(GS_RGBA, GS_ZS_NONE);
-	_source_rt     = std::make_shared<streamfx::obs::gs::rendertarget>(GS_RGBA, GS_ZS_NONE);
-	_vertex_buffer = std::make_shared<streamfx::obs::gs::vertex_buffer>(uint32_t(4u), uint8_t(1u));
 	{
-		auto file = streamfx::data_file_path("effects/standard.effect");
-		try {
-			_standard_effect = streamfx::obs::gs::effect::create(file.generic_u8string());
-		} catch (const std::exception& ex) {
-			DLOG_ERROR("Error loading '%s' from disk: %s", file.generic_u8string().c_str(), ex.what());
-		}
-	}
-	{
-		auto file = streamfx::data_file_path("effects/transform.effect");
-		try {
-			_transform_effect = streamfx::obs::gs::effect::create(file.generic_u8string());
-		} catch (const std::exception& ex) {
-			DLOG_ERROR("Error loading '%s' from disk: %s", file.generic_u8string().c_str(), ex.what());
-		}
-	}
-	{
-		_sampler.set_address_mode_u(GS_ADDRESS_CLAMP);
-		_sampler.set_address_mode_v(GS_ADDRESS_CLAMP);
-		_sampler.set_address_mode_w(GS_ADDRESS_CLAMP);
-		_sampler.set_filter(GS_FILTER_LINEAR);
-		_sampler.set_max_anisotropy(8);
-	}
+		auto gctx = obs::gs::context();
 
-	vec3_set(&_params.position, 0, 0, 0);
-	vec3_set(&_params.rotation, 0, 0, 0);
-	vec3_set(&_params.scale, 1, 1, 1);
-	vec3_set(&_params.shear, 0, 0, 0);
+		_cache_rt      = std::make_shared<streamfx::obs::gs::rendertarget>(GS_RGBA, GS_ZS_NONE);
+		_source_rt     = std::make_shared<streamfx::obs::gs::rendertarget>(GS_RGBA, GS_ZS_NONE);
+		_vertex_buffer = std::make_shared<streamfx::obs::gs::vertex_buffer>(uint32_t(4u), uint8_t(1u));
+		{
+			auto file = streamfx::data_file_path("effects/standard.effect");
+			try {
+				_standard_effect = streamfx::obs::gs::effect::create(file);
+			} catch (const std::exception& ex) {
+				DLOG_ERROR("Error loading '%s': %s", file.generic_u8string().c_str(), ex.what());
+			}
+		}
+		{
+			auto file = streamfx::data_file_path("effects/transform.effect");
+			try {
+				_transform_effect = streamfx::obs::gs::effect::create(file);
+			} catch (const std::exception& ex) {
+				DLOG_ERROR("Error loading '%s': %s", file.generic_u8string().c_str(), ex.what());
+			}
+		}
+		{
+			_sampler.set_address_mode_u(GS_ADDRESS_CLAMP);
+			_sampler.set_address_mode_v(GS_ADDRESS_CLAMP);
+			_sampler.set_address_mode_w(GS_ADDRESS_CLAMP);
+			_sampler.set_filter(GS_FILTER_LINEAR);
+			_sampler.set_max_anisotropy(8);
+		}
 
-	vec2_set(&_corners.tl, 0, 0);
-	vec2_set(&_corners.tr, 1, 0);
-	vec2_set(&_corners.bl, 0, 1);
-	vec2_set(&_corners.br, 1, 1);
+		vec3_set(&_params.position, 0, 0, 0);
+		vec3_set(&_params.rotation, 0, 0, 0);
+		vec3_set(&_params.scale, 1, 1, 1);
+		vec3_set(&_params.shear, 0, 0, 0);
+
+		vec2_set(&_corners.tl, 0, 0);
+		vec2_set(&_corners.tr, 1, 0);
+		vec2_set(&_corners.bl, 0, 1);
+		vec2_set(&_corners.br, 1, 1);
+	}
 
 	update(data);
 }

--- a/source/gfx/blur/gfx-blur-box-linear.cpp
+++ b/source/gfx/blur/gfx-blur-box-linear.cpp
@@ -37,11 +37,13 @@
 streamfx::gfx::blur::box_linear_data::box_linear_data()
 {
 	auto gctx = streamfx::obs::gs::context();
-	try {
-		_effect =
-			streamfx::obs::gs::effect::create(streamfx::data_file_path("effects/blur/box-linear.effect").u8string());
-	} catch (...) {
-		DLOG_ERROR("<gfx::blur::box_linear> Failed to load _effect.");
+	{
+		auto file = streamfx::data_file_path("effects/blur/box-linear.effect");
+		try {
+			_effect = streamfx::obs::gs::effect::create(file);
+		} catch (const std::exception& ex) {
+			DLOG_ERROR("Error loading '%s': %s", file.generic_u8string().c_str(), ex.what());
+		}
 	}
 }
 

--- a/source/gfx/blur/gfx-blur-box.cpp
+++ b/source/gfx/blur/gfx-blur-box.cpp
@@ -37,10 +37,13 @@
 streamfx::gfx::blur::box_data::box_data()
 {
 	auto gctx = streamfx::obs::gs::context();
-	try {
-		_effect = streamfx::obs::gs::effect::create(streamfx::data_file_path("effects/blur/box.effect").u8string());
-	} catch (...) {
-		DLOG_ERROR("<gfx::blur::box> Failed to load _effect.");
+	{
+		auto file = streamfx::data_file_path("effects/blur/box.effect");
+		try {
+			_effect = streamfx::obs::gs::effect::create(file);
+		} catch (const std::exception& ex) {
+			DLOG_ERROR("Error loading '%s': %s", file.generic_u8string().c_str(), ex.what());
+		}
 	}
 }
 

--- a/source/gfx/blur/gfx-blur-dual-filtering.cpp
+++ b/source/gfx/blur/gfx-blur-dual-filtering.cpp
@@ -54,11 +54,13 @@
 streamfx::gfx::blur::dual_filtering_data::dual_filtering_data()
 {
 	auto gctx = streamfx::obs::gs::context();
-	try {
-		_effect = streamfx::obs::gs::effect::create(
-			streamfx::data_file_path("effects/blur/dual-filtering.effect").u8string());
-	} catch (...) {
-		DLOG_ERROR("<gfx::blur::box_linear> Failed to load _effect.");
+	{
+		auto file = streamfx::data_file_path("effects/blur/dual-filtering.effect");
+		try {
+			_effect = streamfx::obs::gs::effect::create(file);
+		} catch (const std::exception& ex) {
+			DLOG_ERROR("Error loading '%s': %s", file.generic_u8string().c_str(), ex.what());
+		}
 	}
 }
 

--- a/source/gfx/blur/gfx-blur-gaussian-linear.cpp
+++ b/source/gfx/blur/gfx-blur-gaussian-linear.cpp
@@ -42,9 +42,18 @@
 
 streamfx::gfx::blur::gaussian_linear_data::gaussian_linear_data()
 {
-	auto gctx = streamfx::obs::gs::context();
-	_effect =
-		streamfx::obs::gs::effect::create(streamfx::data_file_path("effects/blur/gaussian-linear.effect").u8string());
+	{
+		auto gctx = streamfx::obs::gs::context();
+
+		{
+			auto file = streamfx::data_file_path("effects/blur/gaussian-linear.effect");
+			try {
+				_effect = streamfx::obs::gs::effect::create(file);
+			} catch (const std::exception& ex) {
+				DLOG_ERROR("Error loading '%s': %s", file.generic_u8string().c_str(), ex.what());
+			}
+		}
+	}
 
 	// Precalculate Kernels
 	for (std::size_t kernel_size = 1; kernel_size <= ST_MAX_BLUR_SIZE; kernel_size++) {

--- a/source/gfx/blur/gfx-blur-gaussian.cpp
+++ b/source/gfx/blur/gfx-blur-gaussian.cpp
@@ -46,8 +46,15 @@ streamfx::gfx::blur::gaussian_data::gaussian_data()
 
 	{
 		auto gctx = streamfx::obs::gs::context();
-		_effect =
-			streamfx::obs::gs::effect::create(streamfx::data_file_path("effects/blur/gaussian.effect").u8string());
+
+		{
+			auto file = streamfx::data_file_path("effects/blur/gaussian.effect");
+			try {
+				_effect = streamfx::obs::gs::effect::create(file);
+			} catch (const std::exception& ex) {
+				DLOG_ERROR("Error loading '%s': %s", file.generic_u8string().c_str(), ex.what());
+			}
+		}
 	}
 
 	//#define ST_USE_PASCAL_TRIANGLE

--- a/source/obs/gs/gs-effect.hpp
+++ b/source/obs/gs/gs-effect.hpp
@@ -49,14 +49,19 @@ namespace streamfx::obs::gs {
 			return get();
 		}
 
-		static streamfx::obs::gs::effect create(const std::string& file)
-		{
-			return streamfx::obs::gs::effect(file);
-		};
-
 		static streamfx::obs::gs::effect create(const std::string& code, const std::string& name)
 		{
 			return streamfx::obs::gs::effect(code, name);
+		};
+
+		static streamfx::obs::gs::effect create(const std::string& file)
+		{
+			return streamfx::obs::gs::effect(std::filesystem::path(file));
+		};
+
+		static streamfx::obs::gs::effect create(const std::filesystem::path& file)
+		{
+			return streamfx::obs::gs::effect(file);
 		};
 	};
 } // namespace streamfx::obs::gs

--- a/source/obs/gs/gs-mipmapper.cpp
+++ b/source/obs/gs/gs-mipmapper.cpp
@@ -45,6 +45,8 @@ streamfx::obs::gs::mipmapper::~mipmapper()
 
 streamfx::obs::gs::mipmapper::mipmapper()
 {
+	auto gctx = streamfx::obs::gs::context();
+
 	_vb = std::make_unique<streamfx::obs::gs::vertex_buffer>(uint32_t(3u), uint8_t(1u));
 
 	{
@@ -71,7 +73,14 @@ streamfx::obs::gs::mipmapper::mipmapper()
 
 	_vb->update();
 
-	_effect = streamfx::obs::gs::effect::create(streamfx::data_file_path("effects/mipgen.effect").u8string());
+	{
+		auto file = streamfx::data_file_path("effects/mipgen.effect");
+		try {
+			_effect = streamfx::obs::gs::effect::create(file);
+		} catch (const std::exception& ex) {
+			DLOG_ERROR("Error loading '%s': %s", file.generic_u8string().c_str(), ex.what());
+		}
+	}
 }
 
 void streamfx::obs::gs::mipmapper::rebuild(std::shared_ptr<streamfx::obs::gs::texture> source,


### PR DESCRIPTION
### Explain the Pull Request
- Adds a simple pre-processor to handle basic preprocessor commands like `#include` in a useful way. This fixes some compatibility problems across graphics APIs.
- Adjusts many locations which incorrectly did not handle the exceptions from shaders correctly.
- Adjusts all effect files which use `texture2D` instead of `texture2d`

### Checklist
- [x] I will become the maintainer for this part of code.
- [x] I have tested this code on all supported Platforms.

### Related Issues
- Fixes #696 

