### PR TITLE
cmake: Fix code signing on Windows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -86,12 +86,12 @@ jobs:
       run: |
         # Restore the Certificate back into a file.
         echo "${{ secrets.CODESIGN_CERT_WIN }}" | base64 --decode > "${{ github.workspace }}/cert.pfx"
-        echo "::set-output name=cmake_args::-DENABLE_CODESIGN=ON -DCODESIGN_TIMESTAMPS=OFF"
+        echo "::set-output name=cmake_args::-DENABLE_CODESIGN=ON -DCODESIGN_TIMESTAMPS=ON"
     - name: "StreamFX: Configure"
       shell: bash
       env:
-        CODESIGN_CERT_PASS: ${{ secrets.CODESIGN_CERT_WIN_PASSWORD }}
-        CODESIGN_CERT_FILE: ${{ github.workspace }}/cert.pfx
+        CODESIGN_FILE: ${{ github.workspace }}/cert.pfx
+        CODESIGN_PASS: ${{ secrets.CODESIGN_CERT_WIN_PASSWORD }}
       run: |
         cmake -H. -B"build/temp" \
           ${{ steps.codesign.outputs.cmake_args }} \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -356,6 +356,26 @@ endif()
 if(${PREFIX}ENABLE_CODESIGN AND (EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/cmake/codesign/CodeSign.cmake"))
 	include("cmake/codesign/CodeSign.cmake")
 	set(HAVE_CODESIGN ON)
+
+	set(${PREFIX}CODESIGN_FILE "" CACHE FILEPATH "Path to Code-Signing certificate.")
+	if(WIN32)
+		set(${PREFIX}CODESIGN_NAME "" CACHE STRING "Name of Code-Signing certificate in Windows's certificate storage.")
+	endif()
+	set(${PREFIX}CODESIGN_PASS "" CACHE STRING "Password for Code-Signing certificate.")
+	set(${PREFIX}CODESIGN_TIMESTAMPS ON CACHE BOOL "Should the resulting binary be timestamped?")
+
+	set(_CODESIGN_FILE "$ENV{${PREFIX}CODESIGN_FILE}")
+	if(${PREFIX}CODESIGN_FILE)
+		set(_CODESIGN_FILE "${${PREFIX}CODESIGN_FILE}")
+	endif()
+	set(_CODESIGN_NAME "$ENV{${PREFIX}CODESIGN_NAME}")
+	if(${PREFIX}CODESIGN_NAME)
+		set(_CODESIGN_NAME "${${PREFIX}CODESIGN_NAME}")
+	endif()
+	set(_CODESIGN_PASS "$ENV{${PREFIX}CODESIGN_PASS}")
+	if(${PREFIX}CODESIGN_PASS)
+		set(_CODESIGN_PASS "${${PREFIX}CODESIGN_PASS}")
+	endif()
 endif()
 
 ################################################################################
@@ -1930,7 +1950,17 @@ endif()
 
 # Code Sign
 if(HAVE_CODESIGN)
-	codesign(TARGETS ${PROJECT_NAME})
+	set(_CODESIGN_TIMESTAMP "")
+	if(${PREFIX}CODESIGN_TIMESTAMPS)
+		set(_CODESIGN_TIMESTAMP "TIMESTAMPS")
+	endif()
+	codesign(
+		TARGETS ${PROJECT_NAME}
+		CERTIFICATE_FILE "${_CODESIGN_FILE}"
+		CERTIFICATE_NAME "${_CODESIGN_NAME}"
+		CERTIFICATE_PASS "${_CODESIGN_PASS}"
+		${_CODESIGN_TIMESTAMP}
+	)
 endif()
 
 ################################################################################
@@ -2129,8 +2159,24 @@ if(NOT ${PREFIX}OBS_NATIVE)
 			file(TO_NATIVE_PATH "${ISS_MSVCHELPER_PATH}" ISS_MSVCHELPER_PATH)
 
 			if(HAVE_CODESIGN)
-				codesign_command_win32(SHA1 RETURN_BIN ISS_CODESIGN_BIN_SHA1 RETURN_ARGS ISS_CODESIGN_CMD_SHA1)
-				codesign_command_win32(SHA2 APPEND RETURN_BIN ISS_CODESIGN_BIN_SHA2 RETURN_ARGS ISS_CODESIGN_CMD_SHA2)
+				codesign_command_win32(
+					SHA1
+					RETURN_BIN ISS_CODESIGN_BIN_SHA1
+					RETURN_ARGS ISS_CODESIGN_CMD_SHA1
+					CERTIFICATE_FILE "${_CODESIGN_FILE}"
+					CERTIFICATE_NAME "${_CODESIGN_NAME}"
+					CERTIFICATE_PASS "${_CODESIGN_PASS}"
+					${_CODESIGN_TIMESTAMP}
+				)
+				codesign_command_win32(
+					SHA2 APPEND
+					RETURN_BIN ISS_CODESIGN_BIN_SHA2
+					RETURN_ARGS ISS_CODESIGN_CMD_SHA2
+					CERTIFICATE_FILE "${_CODESIGN_FILE}"
+					CERTIFICATE_NAME "${_CODESIGN_NAME}"
+					CERTIFICATE_PASS "${_CODESIGN_PASS}"
+					${_CODESIGN_TIMESTAMP}
+				)
 				list(JOIN ISS_CODESIGN_CMD_SHA1 " " ISS_CODESIGN_CMD_SHA1)
 				list(JOIN ISS_CODESIGN_CMD_SHA2 " " ISS_CODESIGN_CMD_SHA2)
 


### PR DESCRIPTION
### Explain the Pull Request
An unknown update broke Code Signing on Windows, resulting in Windows only building unsigned binaries. This fixes it and also allows multiple cmake-codesign projects to use different certificates entirely.

<!-- Describe the PR in as much detail as possible, leave nothing out. -->
<!-- If you think images or example videos help describe the PR, include them. -->
<!-- What makes this PR necessary for StreamFX and it's users? -->

### Related Issues
<!-- Is this PR related to another PR or Issue? List them here. -->
<!-- - #0000 Name of Issue -->
<!-- - #0001 Name of Issue -->

### Checklist
- [x] I will become the maintainer for this part of code.
- [x] I have tested this code on all supported Platforms.
