### PR TITLE
Make STANDALONE setable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -271,7 +271,7 @@ endif()
 # Detect if we are building with OBS Studio (different from Grouped builds)
 ################################################################################
 
-set(STANDALONE ON)
+set(STANDALONE CACHE BOOL ON Build standalone version)
 if(GROUPED AND (TARGET libobs))
 	set(STANDALONE OFF)
 endif()


### PR DESCRIPTION
The autodetection does not work in a nix build environment. This makes the variable setable via command line and gui.

### Explain the Pull Request
<!-- Describe the PR in as much detail as possible, leave nothing out. -->
<!-- If you think images or example videos help describe the PR, include them. -->
<!-- What makes this PR necessary for StreamFX and it's users? -->

### Related Issues
<!-- Is this PR related to another PR or Issue? List them here. -->
<!-- - #0000 Name of Issue -->
<!-- - #0001 Name of Issue -->

### Checklist
- [ ] I will become the maintainer for this part of code.
- [ ] I have tested this code on all supported Platforms.
