### PR TITLE
ci: Add GCC back to the build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,33 @@ jobs:
       fail-fast: true
       matrix:
         runner: [ windows-2022, ubuntu-22.04, macos-12, windows-2019, ubuntu-20.04, macos-11, macos-10.15 ]
+        generator: [ MSVC, GCC, Clang ]
         CMAKE_BUILD_TYPE: [ Debug, RelWithDebInfo ]
+        exclude:
+          - runner: windows-2022
+            generator: GCC
+          - runner: windows-2019
+            generator: GCC
+          - runner: windows-2022
+            generator: Clang
+          - runner: windows-2019
+            generator: Clang
+          - runner: ubuntu-22.04
+            generator: MSVC
+          - runner: ubuntu-20.04
+            generator: MSVC
+          - runner: macos-12
+            generator: MSVC
+          - runner: macos-12
+            generator: GCC
+          - runner: macos-11
+            generator: MSVC
+          - runner: macos-11
+            generator: GCC
+          - runner: macos-10.15
+            generator: MSVC
+          - runner: macos-10.15
+            generator: GCC
         include:
           - runner: windows-2022
             generator: MSVC


### PR DESCRIPTION
### Explain the Pull Request
GCC is still widely used, and sometimes the only supported compiler at all. Should have verified the previous PR added GCC before trusting my own brain to have understood everything correctly.

### Related Issues
<!-- Is this PR related to another PR or Issue? List them here. -->
<!-- - #0000 Name of Issue -->
<!-- - #0001 Name of Issue -->

### Checklist
- [x] I will become the maintainer for this part of code.
- [ ] I have tested this code on all supported Platforms.
