### PR TITLE
ci: Remove Code Signing with self-signed certificate

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -195,15 +195,6 @@ jobs:
           build/temp/autodeps
         key: autodeps-${{ matrix.runner }}-${{ matrix.generator }}-${{ matrix.CMAKE_BUILD_TYPE }}-${{ env.CACHE_VERSION }}
 
-    - name: "Code Signing (Windows)" # Do not run this on pull requests, ever!
-      if: (github.event_name != 'pull_request') && startsWith( matrix.runner, 'windows' )
-      id: codesign
-      shell: bash
-      run: |
-        # Restore the Certificate back into a file.
-        echo "${{ secrets.CODESIGN_CERT_WIN }}" | base64 --decode > "${{ github.workspace }}/cert.pfx"
-        echo "::set-output name=cmake_args::-DENABLE_CODESIGN=ON -DCODESIGN_TIMESTAMPS=ON"
-
     - name: "Configure"
       shell: bash
       env:
@@ -216,7 +207,6 @@ jobs:
           ENABLE_PROFILING=OFF
         fi
         cmake -H. -B"build/temp" \
-          ${{ steps.codesign.outputs.cmake_args }} \
           -DCMAKE_BUILD_TYPE=${{ matrix.CMAKE_BUILD_TYPE }} \
           -DCMAKE_INSTALL_PREFIX="build/distrib" \
           -DPACKAGE_NAME="streamfx-${{ matrix.PACKAGE_NAME }}" \
@@ -257,22 +247,12 @@ jobs:
         cmake --build "build/temp" --config RelWithDebInfo --target PACKAGE_7Z
         cmake --build "build/temp" --config RelWithDebInfo --target PACKAGE_ZIP
 
-    - name: "Package: Installer Code Signing (Windows)"
-      if: (github.event_name != 'pull_request') && startsWith( matrix.runner, 'windows' )
-      id: codesign_install
-      shell: bash
-      run: |
-        if [[ -f "${{ github.workspace }}/cert.pfx" ]]; then
-          signtool=$(awk 'match($0, /^;signtool=(.+)$/, ary) {print ary[1]}' "${{ github.workspace }}/build/temp/installer.iss")
-          echo "::set-output name=iscc_signtool::${signtool}"
-        fi
-
     - name: "Package: Installer (Windows)"
       if: startsWith( matrix.runner, 'windows' )
       shell: cmd
       run: |
-        echo '"C:\Program Files (x86)\Inno Setup 6\ISCC.exe" /V10 "/Ssigntool=${{ steps.codesign_install.outputs.iscc_signtool }} $p" ".\build\temp\installer.iss"'
-        "C:\Program Files (x86)\Inno Setup 6\ISCC.exe" /V10 "/Ssigntool=${{ steps.codesign_install.outputs.iscc_signtool }} $p" ".\build\temp\installer.iss"
+        echo '"C:\Program Files (x86)\Inno Setup 6\ISCC.exe" /V10 ".\build\temp\installer.iss"'
+        "C:\Program Files (x86)\Inno Setup 6\ISCC.exe" /V10 ".\build\temp\installer.iss"
 
     - name: "Package: Installer (MacOS)"
       if: startsWith( matrix.runner, 'macos' )


### PR DESCRIPTION
### Explain the Pull Request
Removes the mostly useless self-signed certificate from CI. 

#### Completion Checklist
- [x] I have added myself to the Copyright and License headers and files.
- [x] I will maintain this code in the future and have added myself to `CODEOWNERS`.
- I have tested this change on the following platforms:
  - [ ] MacOS 10.15
  - [ ] MacOS 11
  - [ ] MacOS 12
  - [ ] Ubuntu 20.04
  - [ ] Ubuntu 22.04
  - [ ] Windows 10
  - [ ] Windows 11
