### PR TITLE
Deduplicate CI build pipeline

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -86,6 +86,7 @@ jobs:
       run: |
         curl "-kL" "https://github.com/llvm/llvm-project/releases/download/llvmorg-14.0.4/LLVM-14.0.4-win64.exe" "-f" "--retry" "5" "-o" "llvm.exe"
         7z x -y -o"C:\Program Files\LLVM" llvm.exe "bin" "include" "lib" "libexec" "share" "Uninstall.exe"
+        echo "CLANG_PATH=\"C:\\Program Files\\LLVM\\bin\"" >> "${GITHUB_ENV}"
         curl "-kL" "https://cdn.xaymar.com/ci/innosetup-6.2.1.exe" "-f" "--retry" "5" "-o" "inno.exe"
         .\inno.exe /VERYSILENT /SP- /SUPPRESSMSGBOXES /NORESTART
 
@@ -112,6 +113,7 @@ jobs:
         sudo /tmp/llvm.sh 14 all
         sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-14 800
         sudo update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-14 800
+        echo "CLANG_PATH=/usr/bin" >> "${GITHUB_ENV}"
 
         # Compiler
         if [[ "${{ matrix.generator }}" = "GCC" ]]; then
@@ -139,6 +141,7 @@ jobs:
         sudo hdiutil attach ./Packages.dmg
         pushd /Volumes/Packages*
         sudo installer -pkg ./Install\ Packages.pkg -target /
+        echo "CLANG_PATH=$(brew --prefix llvm@14)/bin/" >> "${GITHUB_ENV}"
 
     - name: "Auto-Dependency Cache"
       if: github.event_name != 'pull_request'
@@ -158,7 +161,7 @@ jobs:
           -DCMAKE_INSTALL_PREFIX="build/debug/install" \
           -DPACKAGE_NAME="streamfx-${{ matrix.package_name }}-debug" \
           -DPACKAGE_PREFIX="build/package" \
-          -DENABLE_CLANG=TRUE \
+          -DENABLE_CLANG=TRUE -DCLANG_PATH="${{ env.CLANG_PATH }}" \
           -DENABLE_PROFILING=ON
         if [[ "${{ matrix.runner }}" = windows* ]]; then
           cmake --build "build/debug" --config Debug --target INSTALL
@@ -167,7 +170,6 @@ jobs:
         elif [[ "${{ matrix.runner }}" = macos* ]]; then
           cmake --build "build/debug" --config Debug --target install
         fi
-        cmake --build "build/debug" --config Debug --target StreamFX_clang-format
 
     - name: "Configure & Build (Release)"
       shell: bash
@@ -177,7 +179,7 @@ jobs:
           -DCMAKE_INSTALL_PREFIX="build/release/install" \
           -DPACKAGE_NAME="streamfx-${{ matrix.package_name }}" \
           -DPACKAGE_PREFIX="build/package" \
-          -DENABLE_CLANG=TRUE \
+          -DENABLE_CLANG=TRUE -DCLANG_PATH="${{ env.CLANG_PATH }}" \
           -DENABLE_PROFILING=OFF
         if [[ "${{ matrix.runner }}" = windows* ]]; then
           cmake --build "build/release" --config RelWithDebInfo --target INSTALL
@@ -186,12 +188,12 @@ jobs:
         elif [[ "${{ matrix.runner }}" = macos* ]]; then
           cmake --build "build/release" --config RelWithDebInfo --target install
         fi
-        cmake --build "build/release" --config RelWithDebInfo --target StreamFX_clang-format
 
     - name: "Validate Formatting"
-      continue-on-error: false
       shell: bash
       run: |
+        cmake --build "build/debug" --config Debug --target StreamFX_clang-format
+        cmake --build "build/release" --config RelWithDebInfo --target StreamFX_clang-format
         git --no-pager diff --patch --minimal HEAD --
         git update-index --refresh
         git diff-index --quiet HEAD --

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,6 @@ jobs:
       matrix:
         runner: [ windows-2022, ubuntu-22.04, macos-12, windows-2019, ubuntu-20.04, macos-11, macos-10.15 ]
         generator: [ MSVC, GCC, Clang ]
-        CMAKE_BUILD_TYPE: [ Debug, RelWithDebInfo ]
         exclude:
           - runner: windows-2022
             generator: GCC
@@ -192,73 +191,79 @@ jobs:
       uses: actions/cache@v3
       with:
         path: |
-          build/temp/autodeps
-        key: autodeps-${{ matrix.runner }}-${{ matrix.generator }}-${{ matrix.CMAKE_BUILD_TYPE }}-${{ env.CACHE_VERSION }}
+          build/debug/autodeps
+          build/release/autodeps
+        key: autodeps-${{ matrix.runner }}-${{ matrix.generator }}-${{ env.CACHE_VERSION }}
 
-    - name: "Configure"
+    - name: "Configure & Build (Debug)"
+      continue-on-error: true
       shell: bash
-      env:
-        CODESIGN_FILE: ${{ github.workspace }}/cert.pfx
-        CODESIGN_PASS: ${{ secrets.CODESIGN_CERT_WIN_PASSWORD }}
       run: |
-        if [[ "${{ matrix.CMAKE_BUILD_TYPE }}" = "Debug" ]]; then
-          ENABLE_PROFILING=ON
-        else
-          ENABLE_PROFILING=OFF
-        fi
-        cmake -H. -B"build/temp" \
-          -DCMAKE_BUILD_TYPE=${{ matrix.CMAKE_BUILD_TYPE }} \
-          -DCMAKE_INSTALL_PREFIX="build/distrib" \
-          -DPACKAGE_NAME="streamfx-${{ matrix.PACKAGE_NAME }}" \
+        cmake -H. -B"build/debug" \
+          -DCMAKE_BUILD_TYPE=Debug \
+          -DCMAKE_INSTALL_PREFIX="build/debug/install" \
+          -DPACKAGE_NAME="streamfx-${{ matrix.package_name }}-debug" \
           -DPACKAGE_PREFIX="build/package" \
           -DENABLE_CLANG=TRUE \
-          -DENABLE_PROFILING=${ENABLE_PROFILING}
+          -DENABLE_PROFILING=ON
+        if [[ "${{ matrix.runner }}" = windows* ]]; then
+          cmake --build "build/debug" --config Debug --target INSTALL
+        elif [[ "${{ matrix.runner }}" = ubuntu* ]]; then
+          cmake --build "build/debug" --config Debug --target install
+        elif [[ "${{ matrix.runner }}" = macos* ]]; then
+          cmake --build "build/debug" --config Debug --target install
+        fi
+        cmake --build "build/debug" --config Debug --target StreamFX_clang-tidy
+        cmake --build "build/debug" --config Debug --target StreamFX_clang-format
 
-    - name: "Validation: clang-tidy"
-      continue-on-error: true
+    - name: "Configure & Build (Release)"
       shell: bash
       run: |
-        cmake --build "build/temp" --config ${{ matrix.CMAKE_BUILD_TYPE }} --target StreamFX_clang-tidy
+        cmake -H. -B"build/release" \
+          -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+          -DCMAKE_INSTALL_PREFIX="build/release/install" \
+          -DPACKAGE_NAME="streamfx-${{ matrix.package_name }}" \
+          -DPACKAGE_PREFIX="build/package" \
+          -DENABLE_CLANG=TRUE \
+          -DENABLE_PROFILING=OFF
+        if [[ "${{ matrix.runner }}" = windows* ]]; then
+          cmake --build "build/release" --config RelWithDebInfo --target INSTALL
+        elif [[ "${{ matrix.runner }}" = ubuntu* ]]; then
+          cmake --build "build/release" --config RelWithDebInfo --target install/strip
+        elif [[ "${{ matrix.runner }}" = macos* ]]; then
+          cmake --build "build/release" --config RelWithDebInfo --target install
+        fi
+        cmake --build "build/release" --config RelWithDebInfo --target StreamFX_clang-tidy
+        cmake --build "build/release" --config RelWithDebInfo --target StreamFX_clang-format
 
-    - name: "Validation: Formatting (clang-format)"
-      continue-on-error: true
+    - name: "Validate Formatting"
+      continue-on-error: false
       shell: bash
       run: |
-        cmake --build "build/temp" --config ${{ matrix.CMAKE_BUILD_TYPE }} --target StreamFX_clang-format
         git --no-pager diff --patch --minimal HEAD --
         git update-index --refresh
         git diff-index --quiet HEAD --
-
-    - name: "Build"
-      shell: bash
-      run: |
-        if [[ "${{ matrix.runner }}" = windows* ]]; then
-          cmake --build "build/temp" --config RelWithDebInfo --target INSTALL
-        elif [[ "${{ matrix.runner }}" = ubuntu* ]]; then
-          cmake --build "build/temp" --config RelWithDebInfo --target install/strip
-        elif [[ "${{ matrix.runner }}" = macos* ]]; then
-          cmake --build "build/temp" --config RelWithDebInfo --target install
-        fi
 
     - name: "Package: Archives"
       shell: bash
       run: |
         mkdir build/package
-        cmake --build "build/temp" --config RelWithDebInfo --target PACKAGE_7Z
-        cmake --build "build/temp" --config RelWithDebInfo --target PACKAGE_ZIP
+        cmake --build "build/debug" --config RelWithDebInfo --target PACKAGE_7Z
+        cmake --build "build/release" --config RelWithDebInfo --target PACKAGE_7Z
 
     - name: "Package: Installer (Windows)"
       if: startsWith( matrix.runner, 'windows' )
       shell: cmd
       run: |
-        echo '"C:\Program Files (x86)\Inno Setup 6\ISCC.exe" /V10 ".\build\temp\installer.iss"'
-        "C:\Program Files (x86)\Inno Setup 6\ISCC.exe" /V10 ".\build\temp\installer.iss"
+        "C:\Program Files (x86)\Inno Setup 6\ISCC.exe" /V10 ".\build\debug\installer.iss"
+        "C:\Program Files (x86)\Inno Setup 6\ISCC.exe" /V10 ".\build\release\installer.iss"
 
     - name: "Package: Installer (MacOS)"
       if: startsWith( matrix.runner, 'macos' )
       shell: bash
       run: |
-        packagesbuild ./build/temp/installer.pkgproj
+        packagesbuild ./build/debug/installer.pkgproj
+        packagesbuild ./build/release/installer.pkgproj
 
     - name: "Artifacts"
       uses: actions/upload-artifact@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -167,7 +167,6 @@ jobs:
         elif [[ "${{ matrix.runner }}" = macos* ]]; then
           cmake --build "build/debug" --config Debug --target install
         fi
-        cmake --build "build/debug" --config Debug --target StreamFX_clang-tidy
         cmake --build "build/debug" --config Debug --target StreamFX_clang-format
 
     - name: "Configure & Build (Release)"
@@ -187,7 +186,6 @@ jobs:
         elif [[ "${{ matrix.runner }}" = macos* ]]; then
           cmake --build "build/release" --config RelWithDebInfo --target install
         fi
-        cmake --build "build/release" --config RelWithDebInfo --target StreamFX_clang-tidy
         cmake --build "build/release" --config RelWithDebInfo --target StreamFX_clang-format
 
     - name: "Validate Formatting"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,114 +23,57 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runner: [ windows-2022, ubuntu-22.04, macos-12, windows-2019, ubuntu-20.04, macos-11, macos-10.15 ]
+        runner: [ windows-2022, macos-12, ubuntu-22.04, ubuntu-20.04 ]
         generator: [ MSVC, GCC, Clang ]
         exclude:
           - runner: windows-2022
             generator: GCC
-          - runner: windows-2019
-            generator: GCC
           - runner: windows-2022
             generator: Clang
-          - runner: windows-2019
-            generator: Clang
+          - runner: macos-12
+            generator: MSVC
+          - runner: macos-12
+            generator: GCC
           - runner: ubuntu-22.04
             generator: MSVC
           - runner: ubuntu-20.04
             generator: MSVC
-          - runner: macos-12
-            generator: MSVC
-          - runner: macos-12
-            generator: GCC
-          - runner: macos-11
-            generator: MSVC
-          - runner: macos-11
-            generator: GCC
-          - runner: macos-10.15
-            generator: MSVC
-          - runner: macos-10.15
-            generator: GCC
         include:
+          # Windows supports MSVC
           - runner: windows-2022
-            generator: MSVC
-            experimental: true
-            platform: "Windows 11"
-            PACKAGE_NAME: "windows-11"
-            CMAKE_SYSTEM_VERSION: "10.0.22000.0"
+            name: "Windows"
+            package_name: "windows"
+            CMAKE_SYSTEM_VERSION: "10.0.20348.0"
             CMAKE_GENERATOR: "Visual Studio 17 2022"
             CMAKE_GENERATOR_PLATFORM: "x64"
-          - runner: windows-2019
-            generator: MSVC
-            experimental: false
-            platform: "Windows 10"
-            PACKAGE_NAME: "windows-10"
-            CMAKE_SYSTEM_VERSION: "10.0.19041.0"
-            CMAKE_GENERATOR: "Visual Studio 16 2019"
-            CMAKE_GENERATOR_PLATFORM: "x64"
-          - runner: ubuntu-22.04
-            generator: GCC
-            experimental: false
-            platform: "Ubuntu 22"
-            compiler_c: gcc
-            compiler_cxx: g++
-            PACKAGE_NAME: "ubuntu-22-gcc"
-            CMAKE_GENERATOR: "Ninja"
-          - runner: ubuntu-20.04
-            generator: GCC
-            experimental: false
-            platform: "Ubuntu 20"
-            compiler_c: gcc
-            compiler_cxx: g++
-            PACKAGE_NAME: "ubuntu-20-gcc"
-            CMAKE_GENERATOR: "Ninja"
-          - runner: ubuntu-22.04
-            generator: Clang
-            experimental: false
-            platform: "Ubuntu 22"
-            compiler_c: clang
-            compiler_cxx: clang++
-            PACKAGE_NAME: "ubuntu-22-clang"
-            CMAKE_GENERATOR: "Ninja"
-          - runner: ubuntu-20.04
-            generator: Clang
-            experimental: false
-            platform: "Ubuntu 20"
-            compiler_c: clang
-            compiler_cxx: clang++
-            PACKAGE_NAME: "ubuntu-20-clang"
-            CMAKE_GENERATOR: "Ninja"
+
+          # MacOS supports Clang
           - runner: macos-12
-            generator: Clang
-            experimental: true
-            platform: "MacOS 12"
-            PACKAGE_NAME: "macos-12"
+            name: "MacOS"
+            package_name: "macos"
             CMAKE_GENERATOR: "Xcode"
             CMAKE_OSX_DEPLOYMENT_TARGET: "10.15"
-          - runner: macos-11
-            generator: Clang
-            experimental: false
-            platform: "MacOS 11"
-            PACKAGE_NAME: "macos-11"
-            CMAKE_GENERATOR: "Xcode"
-            CMAKE_OSX_DEPLOYMENT_TARGET: "10.15"
-          - runner: macos-10.15
-            generator: Clang
-            experimental: true
-            platform: "MacOS 10.15"
-            PACKAGE_NAME: "macos-10.15"
-            CMAKE_GENERATOR: "Xcode"
-            CMAKE_OSX_DEPLOYMENT_TARGET: "10.15"
-    name: "${{ matrix.platform }} (${{ matrix.generator }}, ${{ matrix.CMAKE_BUILD_TYPE }})"
+            CMAKE_OSX_ARCHITECTURES: "x86_64"
+
+          # Ubuntu needs version-specific binaries
+          - runner: ubuntu-22.04
+            name: "Ubuntu 22.04"
+            package_name: "ubuntu-22"
+            CMAKE_GENERATOR: "Ninja"
+          - runner: ubuntu-20.04
+            name: "Ubuntu 20.04"
+            package_name: "ubuntu-20"
+            CMAKE_GENERATOR: "Ninja"
+
     runs-on: ${{ matrix.runner }}
-    continue-on-error: ${{ matrix.experimental }}
+    name: "${{ matrix.name }} (${{ matrix.generator }})"
     env:
-      CC: ${{ matrix.compiler_c }}
-      CXX: ${{ matrix.compiler_cxx }}
-      CMAKE_GENERATOR: ${{ matrix.CMAKE_GENERATOR }}
-      CMAKE_GENERATOR_PLATFORM: ${{ matrix.CMAKE_GENERATOR_PLATFORM }}
-      CMAKE_GENERATOR_TOOLSET: ${{ matrix.CMAKE_GENERATOR_TOOLSET }}
-      CMAKE_SYSTEM_VERSION: ${{ matrix.CMAKE_SYSTEM_VERSION }}
+      CMAKE_GENERATOR: "${{ matrix.CMAKE_GENERATOR }}"
+      CMAKE_GENERATOR_PLATFORM: "${{ matrix.CMAKE_GENERATOR_PLATFORM }}"
+      CMAKE_GENERATOR_TOOLSET: "${{ matrix.CMAKE_GENERATOR_TOOLSET }}"
+      CMAKE_SYSTEM_VERSION: "${{ matrix.CMAKE_SYSTEM_VERSION }}"
       CMAKE_OSX_DEPLOYMENT_TARGET: "${{ matrix.CMAKE_OSX_DEPLOYMENT_TARGET }}"
+      CMAKE_OSX_ARCHITECTURES: "${{ matrix.CMAKE_OSX_ARCHITECTURES }}"
     steps:
     - name: "Clone"
       uses: actions/checkout@v3
@@ -162,19 +105,30 @@ jobs:
           qtbase5-dev qtbase5-private-dev libqt5svg5-dev \
           libavcodec-dev libavdevice-dev libavfilter-dev libavformat-dev libavutil-dev libswresample-dev libswscale-dev \
           libcurl4-openssl-dev
+
+        # clang-format, clang-tidy
+        curl -jLo /tmp/llvm.sh "https://apt.llvm.org/llvm.sh"
+        chmod +x /tmp/llvm.sh
+        sudo /tmp/llvm.sh 14 all
+        sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-14 800
+        sudo update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-14 800
+
+        # Compiler
         if [[ "${{ matrix.generator }}" = "GCC" ]]; then
           sudo apt-get install gcc-10 g++10
           sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 800 --slave /usr/bin/g++ g++ /usr/bin/g++-10
+          echo "CC=gcc-10" >> "${GITHUB_ENV}"
+          echo "CXX=gcc-10" >> "${GITHUB_ENV}"
+          echo "LD=ld" >> "${GITHUB_ENV}"
         elif [[ "${{ matrix.generator }}" = "Clang" ]]; then
-          curl -jLo /tmp/llvm.sh https://apt.llvm.org/llvm.sh
-          sudo bash -x /tmp/llvm.sh 14 all
           sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-14 800
           sudo update-alternatives --install /usr/bin/clangd clangd /usr/bin/clangd-14 800
           sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-14 800
-          sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-14 800
-          sudo update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-14 800
           sudo update-alternatives --install /usr/bin/lld lld /usr/bin/lld-14 800
           sudo update-alternatives --install /usr/bin/lldb lldb /usr/bin/lldb-14 800
+          echo "CC=clang-14" >> "${GITHUB_ENV}"
+          echo "CXX=clang++-14" >> "${GITHUB_ENV}"
+          echo "LD=lld" >> "${GITHUB_ENV}"
         fi
 
     - name: 'Dependencies: MacOS'


### PR DESCRIPTION
### Explain the Pull Request
The current build pipeline is extremely convoluted for no real gain. Build time can be reduced by opting to merge some of the stages into one element instead, such as platforms and build type.

#### Completion Checklist
- [x] I have added myself to the Copyright and License headers and files.
- [x] I will maintain this code in the future and have added myself to `CODEOWNERS`.
- I have tested this change on the following platforms:
  - [ ] MacOS 10.15
  - [ ] MacOS 11
  - [ ] MacOS 12
  - [ ] Ubuntu 20.04
  - [ ] Ubuntu 22.04
  - [ ] Windows 10
  - [ ] Windows 11
