### PR TITLE
obs/gs/effect: Revert #836

### DIFF
--- a/source/obs/gs/gs-effect.cpp
+++ b/source/obs/gs/gs-effect.cpp
@@ -29,9 +29,9 @@
 
 static std::string load_file_as_code(const std::filesystem::path& shader_file, bool is_top_level = true)
 {
-	std::stringstream            shader_stream;
-	const std::filesystem::path& shader_path = std::filesystem::absolute(shader_file);
-	const std::filesystem::path& shader_root = std::filesystem::path(shader_path).remove_filename();
+	std::stringstream           shader_stream;
+	const std::filesystem::path shader_path = std::filesystem::absolute(shader_file.native());
+	const std::filesystem::path shader_root = std::filesystem::path(shader_path.native()).remove_filename();
 
 	// Ensure it meets size limits.
 	uintmax_t size = std::filesystem::file_size(shader_path);


### PR DESCRIPTION
### Explain the Pull Request
The use of const references breaks '#include' for relative paths.

#### Completion Checklist
- [x] I have added myself to the Copyright and License headers and files.
- [ ] I will maintain this code in the future and have added myself to `CODEOWNERS`.
- I have tested this change on the following platforms:
  - [ ] MacOS 10.15
  - [ ] MacOS 11
  - [ ] MacOS 12
  - [x] Ubuntu 20.04
  - [x] Ubuntu 22.04
  - [x] Windows 10
  - [x] Windows 11
