### PR TITLE
#881: Texture inputs to Shaders are unstable

### DIFF
--- a/source/filters/filter-dynamic-mask.cpp
+++ b/source/filters/filter-dynamic-mask.cpp
@@ -434,7 +434,7 @@ try {
 
 void dynamic_mask_instance::release()
 {
-	_input = {};
+	_input.reset();
 	_input_capture.reset();
 
 	deactivate();

--- a/source/gfx/shader/gfx-shader-param-texture.hpp
+++ b/source/gfx/shader/gfx-shader-param-texture.hpp
@@ -9,8 +9,8 @@
 #include "obs/obs-source-active-child.hpp"
 #include "obs/obs-source-active-reference.hpp"
 #include "obs/obs-source-showing-reference.hpp"
-#include "obs/obs-source.hpp"
 #include "obs/obs-tools.hpp"
+#include "obs/obs-weak-source.hpp"
 
 namespace streamfx::gfx {
 	namespace shader {
@@ -59,7 +59,7 @@ namespace streamfx::gfx {
 
 			// Data: Source
 			std::string                                              _source_name;
-			::streamfx::obs::source                                  _source;
+			::streamfx::obs::weak_source                             _source;
 			std::shared_ptr<streamfx::obs::source_active_child>      _source_child;
 			std::shared_ptr<streamfx::obs::source_active_reference>  _source_active;
 			std::shared_ptr<streamfx::obs::source_showing_reference> _source_visible;


### PR DESCRIPTION
### Explain the Pull Request
Texture inputs to shaders have become incredibly unstable with later versions, which results in crashes and freezes. As this situation is very much unwanted, this PR should improve the situation massively.

#### Completion Checklist
- [x] I have added myself to the Copyright and License headers and files.
- [x] I will maintain this code in the future and have added myself to `CODEOWNERS`.
- I have tested this change on the following platforms:
  - [x] MacOS 10.15
  - [x] MacOS 11
  - [x] MacOS 12
  - [x] Ubuntu 20.04
  - [x] Ubuntu 22.04
  - [x] Windows 10
  - [x] Windows 11
