### PR TITLE
Deprecate AOM AV1 encoder

### DIFF
--- a/data/locale/en-US.ini
+++ b/data/locale/en-US.ini
@@ -66,6 +66,7 @@ UI.Updater.Menu.Channel.Alpha="Alpha"
 
 # Encoder/AOM-AV1
 Encoder.AOM.AV1="AOM AV1 (direct)"
+Encoder.AOM.AV1.Deprecated="This encoder is deprecated and will be removed soon. Users are urged to switch to the integrated 'SVT-AV1' or 'AOM AV1' encoder as soon as possible."
 Encoder.AOM.AV1.Encoder="Encoder"
 Encoder.AOM.AV1.Encoder.Usage="Usage"
 Encoder.AOM.AV1.Encoder.Usage.GoodQuality="Good Quality"

--- a/source/encoders/encoder-aom-av1.cpp
+++ b/source/encoders/encoder-aom-av1.cpp
@@ -18,6 +18,10 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+//--------------------------------------------------------------------------------//
+// THIS FEATURE IS DEPRECATED. SUBMITTED PATCHES WILL BE REJECTED.
+//--------------------------------------------------------------------------------//
+
 #include "encoder-aom-av1.hpp"
 #include <filesystem>
 #include <thread>
@@ -40,6 +44,7 @@
 #define ST_I18N "Encoder.AOM.AV1"
 
 // Preset
+#define ST_I18N_DEPRECATED ST_I18N ".Deprecated"
 #define ST_I18N_ENCODER ST_I18N ".Encoder"
 #define ST_I18N_ENCODER_USAGE ST_I18N_ENCODER ".Usage"
 #define ST_I18N_ENCODER_USAGE_GOODQUALITY ST_I18N_ENCODER_USAGE ".GoodQuality"
@@ -1263,6 +1268,7 @@ aom_av1_factory::aom_av1_factory()
 	_info.type  = obs_encoder_type::OBS_ENCODER_VIDEO;
 	_info.codec = "av1";
 	_info.caps  = OBS_ENCODER_CAP_DYN_BITRATE;
+	_info.caps |= OBS_ENCODER_CAP_DEPRECATED;
 
 	finish_setup();
 }
@@ -1424,6 +1430,12 @@ try {
 obs_properties_t* aom_av1_factory::get_properties2(instance_t* data)
 {
 	obs_properties_t* props = obs_properties_create();
+
+	{
+		auto p = obs_properties_add_text(props, "[[deprecated]]", D_TRANSLATE(ST_I18N_DEPRECATED), OBS_TEXT_INFO);
+		obs_property_text_set_info_type(p, OBS_TEXT_INFO_WARNING);
+		obs_property_text_set_info_word_wrap(p, true);
+	}
 
 #ifdef ENABLE_FRONTEND
 	{

--- a/source/encoders/encoder-aom-av1.hpp
+++ b/source/encoders/encoder-aom-av1.hpp
@@ -18,6 +18,10 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+//--------------------------------------------------------------------------------//
+// THIS FEATURE IS DEPRECATED. SUBMITTED PATCHES WILL BE REJECTED.
+//--------------------------------------------------------------------------------//
+
 #pragma once
 #include "common.hpp"
 #include <memory>


### PR DESCRIPTION
### Explain the Pull Request
As the integrated 'AOM AV1' and 'SVT-AV1' encoders serve the same purpose, there is no point in providing this anymore.

#### Completion Checklist
- [x] I have added myself to the Copyright and License headers and files.
- [x] I will maintain this code in the future and have added myself to `CODEOWNERS`.
- I have tested this change on the following platforms:
  - [ ] MacOS 10.15
  - [ ] MacOS 11
  - [ ] MacOS 12
  - [ ] Ubuntu 20.04
  - [ ] Ubuntu 22.04
  - [ ] Windows 10
  - [ ] Windows 11
