### PR TITLE
cmake: Require nlohmann-json when building the front-end

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright (C) 2017 Michael Fabian Dirks
+# Copyright (C) 2022 Romain Vigier
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -653,10 +654,14 @@ function(feature_frontend RESOLVE)
 		elseif(NOT obs-frontend-api_FOUND)
 			message(WARNING "${LOGPREFIX}Front-End requires OBS FrontEnd API. Disabling...")
 			set_feature_disabled(FRONTEND ON)
+		elseif(NOT HAVE_JSON)
+			message(WARNING "${LOGPREFIX}Front-End requires nlohmann::json. Disabling...")
+			set_feature_disabled(FRONTEND ON)
 		endif()
 	elseif(T_CHECK)
 		set(REQUIRE_QT ON PARENT_SCOPE)
 		set(REQUIRE_OBS_FRONTEND_API ON PARENT_SCOPE)
+		set(REQUIRE_JSON ON PARENT_SCOPE)
 	endif()
 endfunction()
 


### PR DESCRIPTION
### Explain the Pull Request

Nlohmann-json is [used in the about dialog](https://github.com/Xaymar/obs-StreamFX/blob/master/source/ui/ui-about.cpp#L31), yet wasn't required when building the front-end, leading to failing compilation. This ensures that it is correctly required. See https://github.com/flathub/flathub/pull/3159#issuecomment-1235303799.

#### Completion Checklist
- [x] I have added myself to the Copyright and License headers and files.
- [x] I will maintain this code in the future and have added myself to `CODEOWNERS`. <-- I haven't added myself to CODEOWNERS, do I need to for such a simple patch?
- I have tested this change on the following platforms:
  - [ ] MacOS 10.15
  - [ ] MacOS 11
  - [ ] MacOS 12
  - [ ] Ubuntu 20.04
  - [ ] Ubuntu 22.04
  - [ ] Windows 10
  - [ ] Windows 11
