### PR TITLE
encoder/handler/prores_aw: Don't enable Key-Frame options

### DIFF
--- a/source/encoders/handlers/prores_aw_handler.cpp
+++ b/source/encoders/handlers/prores_aw_handler.cpp
@@ -1,5 +1,5 @@
 // FFMPEG Video Encoder Integration for OBS Studio
-// Copyright (c) 2019 Michael Fabian Dirks <info@xaymar.com>
+// Copyright (c) 2019-2022 Michael Fabian Dirks <info@xaymar.com>
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -111,4 +111,9 @@ void prores_aw_handler::log_options(obs_data_t* settings, const AVCodec* codec, 
 		}
 		return std::string("<Unknown>");
 	});
+}
+
+bool prores_aw_handler::has_keyframe_support(ffmpeg_factory* instance)
+{
+	return false;
 }

--- a/source/encoders/handlers/prores_aw_handler.hpp
+++ b/source/encoders/handlers/prores_aw_handler.hpp
@@ -1,5 +1,5 @@
 // FFMPEG Video Encoder Integration for OBS Studio
-// Copyright (c) 2019 Michael Fabian Dirks <info@xaymar.com>
+// Copyright (c) 2019-2022 Michael Fabian Dirks <info@xaymar.com>
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -43,6 +43,8 @@ namespace streamfx::encoder::ffmpeg::handler {
 
 		public /*support tests*/:
 		bool has_pixel_format_support(ffmpeg_factory* instance) override;
+
+		bool has_keyframe_support(ffmpeg_factory* instance) override;
 
 		public /*settings*/:
 		void get_properties(obs_properties_t* props, const AVCodec* codec, AVCodecContext* context,


### PR DESCRIPTION
### Explain the Pull Request
Removes the useless Key-Frame options from the ProRes encoder. It's an I-only encoder which doesn't actually support this in the first place.

#### Completion Checklist
- [x] I have added myself to the Copyright and License headers and files.
- [ ] I will maintain this code in the future and have added myself to `CODEOWNERS`.
- I have tested this change on the following platforms:
  - [ ] MacOS 10.15
  - [ ] MacOS 11
  - [ ] MacOS 12
  - [ ] Ubuntu 20.04
  - [ ] Ubuntu 22.04
  - [x] Windows 10
  - [ ] Windows 11
