### PR TITLE
encoder/handler/dnxhd: Use endian-independent formats

### DIFF
--- a/source/encoders/handlers/dnxhd_handler.cpp
+++ b/source/encoders/handlers/dnxhd_handler.cpp
@@ -1,3 +1,5 @@
+// Copyright (c) 2022 Michael Fabian Dirks <info@xaymar.com>
+
 #include "dnxhd_handler.hpp"
 #include "common.hpp"
 #include "../codecs/dnxhr.hpp"
@@ -23,8 +25,8 @@ void dnxhd_handler::override_colorformat(AVPixelFormat& target_format, obs_data_
 {
 	static const std::array<std::pair<const char*, AVPixelFormat>, static_cast<size_t>(5)> profile_to_format_map{
 		std::pair{"dnxhr_lb", AV_PIX_FMT_YUV422P}, std::pair{"dnxhr_sq", AV_PIX_FMT_YUV422P},
-		std::pair{"dnxhr_hq", AV_PIX_FMT_YUV422P}, std::pair{"dnxhr_hqx", AV_PIX_FMT_YUV422P10LE},
-		std::pair{"dnxhr_444", AV_PIX_FMT_YUV444P10LE}};
+		std::pair{"dnxhr_hq", AV_PIX_FMT_YUV422P}, std::pair{"dnxhr_hqx", AV_PIX_FMT_YUV422P10},
+		std::pair{"dnxhr_444", AV_PIX_FMT_YUV444P10}};
 
 	const char* selected_profile = obs_data_get_string(settings, S_CODEC_DNXHR_PROFILE);
 	for (const auto& kv : profile_to_format_map) {
@@ -34,7 +36,7 @@ void dnxhd_handler::override_colorformat(AVPixelFormat& target_format, obs_data_
 		}
 	}
 
-	//Fallback for (yet) unknown formats
+	// Fallback for (yet) unknown formats
 	target_format = AV_PIX_FMT_YUV422P;
 }
 


### PR DESCRIPTION
### Explain the Pull Request
Fixes a bug with the DNxHR encoder on some architectures that use a different endianness than StreamFX's DNxHR integration.
<!-- Describe the PR in as much detail as possible. If possible include example images, videos and documents, and explain why it is necessary. If this is related to a discussion or issue, please also link them. -->

#### Completion Checklist
- [x] I have added myself to the Copyright and License headers and files.
- [ ] I will maintain this code in the future and have added myself to `CODEOWNERS`.
- I have tested this change on the following platforms:
  - [ ] MacOS 10.15
  - [ ] MacOS 11
  - [ ] MacOS 12
  - [ ] Ubuntu 20.04
  - [ ] Ubuntu 22.04
  - [x] Windows 10
  - [ ] Windows 11
