### PR TITLE
Save configuration after ~100ms have passed

### DIFF
--- a/source/configuration.cpp
+++ b/source/configuration.cpp
@@ -1,47 +1,52 @@
-/*
- * Modern effects for a modern Streamer
- * Copyright (C) 2020 Michael Fabian Dirks
- *
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
- */
+// Copyright (C) 2020-2022 Michael Fabian Dirks
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 
 #include "configuration.hpp"
 #include "obs/obs-tools.hpp"
 #include "plugin.hpp"
+#include "util/util-logging.hpp"
+
+#ifdef _DEBUG
+#define ST_PREFIX "<%s> "
+#define D_LOG_ERROR(x, ...) P_LOG_ERROR(ST_PREFIX##x, __FUNCTION_SIG__, __VA_ARGS__)
+#define D_LOG_WARNING(x, ...) P_LOG_WARN(ST_PREFIX##x, __FUNCTION_SIG__, __VA_ARGS__)
+#define D_LOG_INFO(x, ...) P_LOG_INFO(ST_PREFIX##x, __FUNCTION_SIG__, __VA_ARGS__)
+#define D_LOG_DEBUG(x, ...) P_LOG_DEBUG(ST_PREFIX##x, __FUNCTION_SIG__, __VA_ARGS__)
+#else
+#define ST_PREFIX "<configuration> "
+#define D_LOG_ERROR(...) P_LOG_ERROR(ST_PREFIX __VA_ARGS__)
+#define D_LOG_WARNING(...) P_LOG_WARN(ST_PREFIX __VA_ARGS__)
+#define D_LOG_INFO(...) P_LOG_INFO(ST_PREFIX __VA_ARGS__)
+#define D_LOG_DEBUG(...) P_LOG_DEBUG(ST_PREFIX __VA_ARGS__)
+#endif
 
 constexpr std::string_view version_tag_name = "Version";
 constexpr std::string_view path_backup_ext  = ".bk";
 
 streamfx::configuration::~configuration()
 {
-	// Update version tag.
-	obs_data_set_int(_data.get(), version_tag_name.data(), STREAMFX_VERSION);
-
 	try {
-		if (_config_path.has_parent_path()) {
-			std::filesystem::create_directories(_config_path.parent_path());
-		}
-		if (!obs_data_save_json_safe(_data.get(), _config_path.u8string().c_str(), ".tmp", path_backup_ext.data())) {
-			throw std::exception();
-		}
+		save();
+		_save_task->wait();
 	} catch (std::exception const& ex) {
 		DLOG_ERROR("Failed to save configuration: %s", ex.what());
 	}
 }
 
-streamfx::configuration::configuration() : _data(), _config_path()
+streamfx::configuration::configuration() : _config_path(), _data(), _task_lock(), _save_task()
 {
 	// Retrieve global configuration path.
 	_config_path = streamfx::config_file_path("config.json");
@@ -60,6 +65,28 @@ streamfx::configuration::configuration() : _data(), _config_path()
 		}
 	} catch (...) {
 		_data = std::shared_ptr<obs_data_t>(obs_data_create(), obs::obs_data_deleter);
+	}
+}
+
+void streamfx::configuration::save()
+{
+	std::lock_guard<std::mutex> lg(_task_lock);
+	if (!_save_task || _save_task->is_completed()) {
+		_save_task = streamfx::threadpool()->push([this](streamfx::util::threadpool::task_data_t) {
+			// ToDo: Implement delayed tasks in ::threadpool.
+			std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+			// Update version tag.
+			obs_data_set_int(_data.get(), version_tag_name.data(), STREAMFX_VERSION);
+
+			if (_config_path.has_parent_path()) {
+				std::filesystem::create_directories(_config_path.parent_path());
+			}
+			if (!obs_data_save_json_safe(_data.get(), _config_path.u8string().c_str(), ".tmp",
+										 path_backup_ext.data())) {
+				D_LOG_ERROR("Failed to save configuration file.", nullptr);
+			}
+		});
 	}
 }
 

--- a/source/configuration.hpp
+++ b/source/configuration.hpp
@@ -1,21 +1,18 @@
-/*
- * Modern effects for a modern Streamer
- * Copyright (C) 2020 Michael Fabian Dirks
- *
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
- */
+// Copyright (C) 2020-2022 Michael Fabian Dirks
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 
 #pragma once
 #include "common.hpp"
@@ -23,17 +20,28 @@
 #include "warning-disable.hpp"
 #include <filesystem>
 #include <memory>
+#include <new>
 #include "warning-enable.hpp"
 
 namespace streamfx {
 	class configuration {
+		std::filesystem::path _config_path;
+
 		std::shared_ptr<obs_data_t> _data;
 
-		std::filesystem::path _config_path;
+#if __cpp_lib_hardware_interference_size >= 201603
+		alignas(std::hardware_destructive_interference_size)
+#endif
+			std::mutex _task_lock;
+
+		std::shared_ptr<streamfx::util::threadpool::task> _save_task;
 
 		public:
 		~configuration();
 		configuration();
+
+		public:
+		void save();
 
 		public:
 		std::shared_ptr<obs_data_t> get();

--- a/source/plugin.cpp
+++ b/source/plugin.cpp
@@ -324,11 +324,11 @@ MODULE_EXPORT void obs_module_unload(void)
 		//	_updater.reset();
 		//#endif
 
-		// Finalize Thread Pool
-		_threadpool.reset();
-
 		// Finalize Configuration
 		streamfx::configuration::finalize();
+
+		// Finalize Thread Pool
+		_threadpool.reset();
 
 		DLOG_INFO("Unloaded Version %s", STREAMFX_VERSION_STRING);
 	} catch (std::exception const& ex) {

--- a/source/ui/ui.cpp
+++ b/source/ui/ui.cpp
@@ -67,6 +67,7 @@ bool streamfx::ui::handler::have_shown_about_streamfx(bool shown)
 	auto data   = config->get();
 	if (shown) {
 		obs_data_set_bool(data.get(), _cfg_have_shown_about.data(), true);
+		config->save();
 	}
 	if (config->is_different_version()) {
 		return false;

--- a/source/updater.cpp
+++ b/source/updater.cpp
@@ -402,6 +402,8 @@ void streamfx::updater::save()
 		obs_data_set_bool(dataptr.get(), ST_CFG_AUTOMATION, _automation);
 		obs_data_set_int(dataptr.get(), ST_CFG_CHANNEL, static_cast<long long>(_channel));
 		obs_data_set_int(dataptr.get(), ST_CFG_LASTCHECKEDAT, static_cast<long long>(_lastcheckedat.count()));
+
+		config->save();
 	}
 }
 


### PR DESCRIPTION
### Explain the Pull Request
To prevent excessive data loss, the configuration should be saved after some time has passed, instead of right before quitting OBS Studio. This addresses #805.

#### Completion Checklist
- [x] I have added myself to the Copyright and License headers and files.
- [ ] I will maintain this code in the future and have added myself to `CODEOWNERS`.
- I have tested this change on the following platforms:
  - [ ] MacOS 10.15
  - [ ] MacOS 11
  - [ ] MacOS 12
  - [ ] Ubuntu 20.04
  - [ ] Ubuntu 22.04
  - [x] Windows 10
  - [ ] Windows 11
